### PR TITLE
Move entry points from setup.py to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-# Copyright 2013-2019 The Salish Sea MEOPAR Contributors
+# Copyright 2013-2021 The Salish Sea MEOPAR Contributors
 # and The University of British Columbia
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,8 +46,8 @@ include_package_data = True
 packages = find:
 python_requires = >=3.5
 install_requires =
-    ; see envs/environment-dev.yaml for conda environment dev installation
-    ; see requirements.txt for versions most recently used in development
+    # see envs/environment-dev.yaml for conda environment dev installation
+    # see requirements.txt for versions most recently used in development
     arrow
     attrs
     cliff!=2.9.0
@@ -55,3 +55,16 @@ install_requires =
     gitpython
     python-hglib
     pyyaml
+    # 'NEMO-Cmd',  ; use python3 -m pip install --editable NEMO-Cmd/
+
+[options.entry_points]
+console_scripts =
+    salishsea = salishsea_cmd.main:main
+
+salishsea.app =
+    combine = nemo_cmd.combine:Combine
+    deflate = nemo_cmd.deflate:Deflate
+    gather = nemo_cmd.gather:Gather
+    prepare = salishsea_cmd.prepare:Prepare
+    run = salishsea_cmd.run:Run
+    split-results = salishsea_cmd.split_results:SplitResults

--- a/setup.py
+++ b/setup.py
@@ -17,18 +17,4 @@
 import setuptools
 
 
-setuptools.setup(
-    entry_points={
-        # The salishsea command:
-        "console_scripts": ["salishsea = salishsea_cmd.main:main"],
-        # Sub-command plug-ins:
-        "salishsea.app": [
-            "combine = nemo_cmd.combine:Combine",
-            "deflate = nemo_cmd.deflate:Deflate",
-            "gather = nemo_cmd.gather:Gather",
-            "prepare = salishsea_cmd.prepare:Prepare",
-            "run = salishsea_cmd.run:Run",
-            "split-results = salishsea_cmd.split_results:SplitResults",
-        ],
-    }
-)
+setuptools.setup()


### PR DESCRIPTION
Supported by setuptools>=51.0.0 since 6-Dec-2020.

This is a step along the way of modernizing packaging.