### PR TITLE
Update sockeye modules & memory request re: new software stack

### DIFF
--- a/salishsea_cmd/run.py
+++ b/salishsea_cmd/run.py
@@ -878,7 +878,7 @@ def _pbs_directives(
     else:
         nodes = math.ceil(n_processors / procs_per_node)
         if SYSTEM == "sockeye":
-            procs_directive = "#PBS -l select={nodes}:ncpus={procs_per_node}:mpiprocs={procs_per_node}:mem=64gb".format(
+            procs_directive = "#PBS -l select={nodes}:ncpus={procs_per_node}:mpiprocs={procs_per_node}:mem=186gb".format(
                 nodes=nodes, procs_per_node=procs_per_node
             )
         else:

--- a/salishsea_cmd/run.py
+++ b/salishsea_cmd/run.py
@@ -1092,11 +1092,11 @@ def _modules():
         ),
         "sockeye": textwrap.dedent(
             """\
-            module load gcc/5.4.0
-            module load openmpi/3.1.5
-            module load netcdf-fortran/4.4.5
-            module load python/3.7.3
-            module load py-setuptools/41.0.1-py3.7.3
+            module load gcc/5.5.0
+            module load openmpi/4.1.1-cuda11-3
+            module load netcdf-fortran/4.5.3-hdf4-support
+            module load python/3.8.10
+            module load py-setuptools/50.3.2
             """
         ),
     }.get(SYSTEM, "")

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -2634,7 +2634,7 @@ class TestBuildBatchScript:
             #PBS -m bea
             #PBS -M me@example.com
             #PBS -A st-sallen1-1
-            #PBS -l select=2:ncpus=40:mpiprocs=40:mem=64gb
+            #PBS -l select=2:ncpus=40:mpiprocs=40:mem=186gb
             # stdout and stderr file paths/names
             #PBS -o results_dir/stdout
             #PBS -e results_dir/stderr
@@ -2868,7 +2868,7 @@ class TestPbsDirectives:
             (
                 "sockeye",
                 32,
-                "#PBS -A st-sallen1-1\n#PBS -l select=2:ncpus=32:mpiprocs=32:mem=64gb",
+                "#PBS -A st-sallen1-1\n#PBS -l select=2:ncpus=32:mpiprocs=32:mem=186gb",
             ),
         ),
     )
@@ -2934,7 +2934,7 @@ class TestPbsDirectives:
             (
                 "sockeye",
                 32,
-                "#PBS -A st-sallen1-1\n#PBS -l select=2:ncpus=32:mpiprocs=32:mem=64gb",
+                "#PBS -A st-sallen1-1\n#PBS -l select=2:ncpus=32:mpiprocs=32:mem=186gb",
             ),
         ),
     )

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -2657,11 +2657,11 @@ class TestBuildBatchScript:
             """\
             GATHER="${PBS_O_HOME}/.local/bin/salishsea gather"
 
-            module load gcc/5.4.0
-            module load openmpi/3.1.5
-            module load netcdf-fortran/4.4.5
-            module load python/3.7.3
-            module load py-setuptools/41.0.1-py3.7.3
+            module load gcc/5.5.0
+            module load openmpi/4.1.1-cuda11-3
+            module load netcdf-fortran/4.5.3-hdf4-support
+            module load python/3.8.10
+            module load py-setuptools/50.3.2
 
             mkdir -p ${RESULTS_DIR}
             cd ${WORK_DIR}
@@ -3183,11 +3183,11 @@ class TestModules:
             modules = salishsea_cmd.run._modules()
         expected = textwrap.dedent(
             """\
-            module load gcc/5.4.0
-            module load openmpi/3.1.5
-            module load netcdf-fortran/4.4.5
-            module load python/3.7.3
-            module load py-setuptools/41.0.1-py3.7.3
+            module load gcc/5.5.0
+            module load openmpi/4.1.1-cuda11-3
+            module load netcdf-fortran/4.5.3-hdf4-support
+            module load python/3.8.10
+            module load py-setuptools/50.3.2
             """
         )
         assert modules == expected


### PR DESCRIPTION
New software stack is designated spack-2021 or Software_Collection/2021.
It became the default production environment on 1-Jul-2022.

Base nodes (both 32 core Skylake and 40 core Cascade Lake) have 192gb of memory with 186gb 
available for jobs.