### PR TITLE
Add --cores-per-node & --cpu-arch options to run sub-command

### DIFF
--- a/docs/breaking_changes.rst
+++ b/docs/breaking_changes.rst
@@ -22,15 +22,35 @@
 :kbd:`SalishSeaCmd` Changes That Break Backward Compatibility
 *************************************************************
 
+.. _BreakingChangesVersion22.2:
+
+Version 22.2
+============
+
+The following change that was introduced in version 22.2 of the :kbd:`SalishSeaCmd`
+package is incompatible with earlier versions:
+
+* Replaced the :kbd:`salishsea run --cedar-broadwell` command-line flag with
+  more generic :kbd:`--cores-per-node` and :kbd:`cpu-arch` options.
+  This change enables more general control of HPC job configuration on clusters
+  where that is applicable
+  (presently :kbd:`sockeye` and :kbd:`cedar`).
+
+  To reproduce the effect of :kbd:`--cedar-broadwell` now,
+  please use :kbd:`--cores-per-node 32 --cpu-arch broadwell`.
+
+
 .. _BreakingChangesVersion19.3:
 
 Version 19.3
 ============
 
-The following changes that were introduced in version 19.3 of the :kbd:`SalishSeaCmd` package are incompatible with earlier versions:
+The following change that was introduced in version 19.3 of the :kbd:`SalishSeaCmd`
+package is incompatible with earlier versions:
 
 * The `gitpython`_ package is now a required dependency.
-  It can be installed with :command:`pip install --user gitpython` or :command:`conda install gitpython` as appropriate for your working environment.
+  It can be installed with :command:`pip install --user gitpython` or
+  :command:`conda install gitpython` as appropriate for your working environment.
 
   .. _gitpython: https://gitpython.readthedocs.io/en/stable/
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -44,7 +44,7 @@
     :target: https://github.com/SalishSeaCast/SalishSeaCmd/actions?query=workflow%3ACI
     :alt: pytest and test coverage analysis
 .. image:: https://codecov.io/gh/SalishSeaCast/SalishSeaCmd/branch/main/graph/badge.svg
-    :target: https://codecov.io/gh/SalishSeaCast/SalishSeaCmd
+    :target: https://app.codecov.io/gh/SalishSeaCast/SalishSeaCmd
     :alt: Codecov Testing Coverage Report
 .. image:: https://github.com/SalishSeaCast/SalishSeaCmd/actions/workflows/codeql-analysis.yaml/badge.svg
       :target: https://github.com/SalishSeaCast/SalishSeaCmd/actions?query=workflow:codeql-analysis
@@ -141,7 +141,7 @@ Coding Style
 The :kbd:`SalishSeaCmd` package uses the `black`_ code formatting tool to maintain a coding style that is very close to `PEP 8`_.
 
 .. _black: https://black.readthedocs.io/en/stable/
-.. _PEP 8: https://www.python.org/dev/peps/pep-0008/
+.. _PEP 8: https://peps.python.org/pep-0008/
 
 :command:`black` is installed as part of the :ref:`SalishSeaCmdDevelopmentEnvironment` setup.
 
@@ -466,7 +466,7 @@ Continuous Integration
     :target: https://github.com/SalishSeaCast/SalishSeaCmd/actions?query=workflow%3ACI
     :alt: GitHub Workflow Status
 .. image:: https://codecov.io/gh/SalishSeaCast/SalishSeaCmd/branch/main/graph/badge.svg
-    :target: https://codecov.io/gh/SalishSeaCast/SalishSeaCmd
+    :target: https://app.codecov.io/gh/SalishSeaCast/SalishSeaCmd
     :alt: Codecov Testing Coverage Report
 
 The :kbd:`SalishSeaCmd` package unit test suite is run and a coverage report is generated whenever changes are pushed to GitHub.
@@ -478,7 +478,7 @@ The testing coverage report is uploaded to `codecov.io`_
 .. _repo actions page: https://github.com/SalishSeaCast/SalishSeaCmd/actions
 .. _repo commits page: https://github.com/SalishSeaCast/SalishSeaCmd/commits/main
 .. _repo code overview page: https://github.com/SalishSeaCast/SalishSeaCmd
-.. _codecov.io: https://codecov.io/gh/SalishSeaCast/SalishSeaCmd
+.. _codecov.io: https://app.codecov.io/gh/SalishSeaCast/SalishSeaCmd
 
 The `GitHub Actions`_ workflow configuration that defines the continuous integration tasks is in the :file:`.github/workflows/pytest-coverage.yaml` file.
 
@@ -520,9 +520,10 @@ License
     :target: https://www.apache.org/licenses/LICENSE-2.0
     :alt: Licensed under the Apache License, Version 2.0
 
-The SalishSeaCast NEMO command processor and documentation are copyright 2013 – present by the `SalishSeaCast Project Contributors`_ and The University of British Columbia.
+The SalishSeaCast NEMO command processor and documentation are copyright 2013 – present
+by the `SalishSeaCast Project Contributors`_ and The University of British Columbia.
 
-.. _SalishSeaCast Project Contributors: https://github.com/SalishSeaCast/docs/blob/master/CONTRIBUTORS.rst
+.. _SalishSeaCast Project Contributors: https://github.com/SalishSeaCast/docs/blob/main/CONTRIBUTORS.rst
 
 They are licensed under the Apache License, Version 2.0.
 https://www.apache.org/licenses/LICENSE-2.0

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,7 +24,8 @@ SalishSeaCast NEMO Command Processor
 
 The SalishSeaCast NEMO command processor,
 :program:`salishsea`,
-is a command-line tool for doing various operations associated with the :ref:`SalishSeaNEMO` model.
+is a command-line tool for doing various operations associated with the
+:ref:`SalishSeaNEMO` model.
 
 The :kbd:`SalishSeaCmd` package is a Python 3 package.
 It is developed and tested under Python 3.7 and should work with Python 3.5 and later.
@@ -32,7 +33,8 @@ It is developed and tested under Python 3.7 and should work with Python 3.5 and 
 This an extensible tool built on the OpenStack ``cliff``
 (`Command Line Interface Formulation Framework`_)
 package.
-It is a NEMO domain-specific command processor tool for the :ref:`SalishSeaNEMO` that uses plug-ins from the `NEMO-Cmd`_ package.
+It is a NEMO domain-specific command processor tool for the :ref:`SalishSeaNEMO`
+that uses plug-ins from the `NEMO-Cmd`_ package.
 
 .. _Command Line Interface Formulation Framework: https://docs.openstack.org/cliff/latest/
 .. _NEMO-Cmd: https://github.com/SalishSeaCast/NEMO-Cmd
@@ -62,10 +64,11 @@ Indices and Tables
 License
 =======
 
-The SalishSeaCmd command processor code and documentation are copyright 2013 – present by the `SalishSeaCast Project Contributors`_ and The University of British Columbia.
+The SalishSeaCmd command processor code and documentation are copyright 2013 – present
+by the `SalishSeaCast Project Contributors`_ and The University of British Columbia.
 
-.. _SalishSeaCast Project Contributors: https://github.com/SalishSeaCast/docs/blob/master/CONTRIBUTORS.rst
+.. _SalishSeaCast Project Contributors: https://github.com/SalishSeaCast/docs/blob/main/CONTRIBUTORS.rst
 
 They are licensed under the Apache License, Version 2.0.
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 Please see the LICENSE file for details of the license.

--- a/docs/subcommands.rst
+++ b/docs/subcommands.rst
@@ -22,7 +22,10 @@
 :command:`salishsea` Sub-Commands
 *********************************
 
-The command :kbd:`salishsea help` produces a list of the available :program:`salishsea` options and sub-commands::
+The command :kbd:`salishsea help` produces a list of the available :program:`salishsea`
+options and sub-commands:
+
+.. code-block:: text
 
   usage: salishsea [--version] [-v | -q] [--log-file LOG_FILE] [-h] [--debug]
 
@@ -44,7 +47,8 @@ The command :kbd:`salishsea help` produces a list of the available :program:`sal
     help           print detailed help for another command (cliff)
     prepare        Prepare a Salish Sea NEMO run.
     run            Prepare, execute, and gather results from a Salish Sea NEMO model run.
-    split-results  Split the results of a multi-day SalishSeaCast NEMO model run (e.g. a hindcast run) into daily results directories.
+    split-results  Split the results of a multi-day SalishSeaCast NEMO model run
+                   (e.g. a hindcast run) into daily results directories.
 
 For details of the arguments and options for a sub-command use
 :command:`salishsea help <sub-command>`.
@@ -54,34 +58,41 @@ For example:
 
     $ salishsea help run
 
-::
+.. code-block:: text
 
-    usage: salishsea run [-h] [--cedar-broadwell] [--deflate]
-                         [--max-deflate-jobs MAX_DEFLATE_JOBS]
+    usage: salishsea run [-h] [--cores-per-node CORES_PER_NODE] [--cpu-arch CPU_ARCH]
+                         [--deflate] [--max-deflate-jobs MAX_DEFLATE_JOBS]
                          [--nocheck-initial-conditions] [--no-submit]
                          [--separate-deflate] [--waitjob WAITJOB] [-q]
                          DESC_FILE RESULTS_DIR
 
     Prepare, execute, and gather the results from a Salish Sea NEMO-3.6 run
-    described in DESC_FILE. The results files from the run are gathered in
-    RESULTS_DIR. If RESULTS_DIR does not exist it will be created.
+    described in DESC_FILE. The results files from the run are gathered in RESULTS_DIR.
+    If RESULTS_DIR does not exist it will be created.
 
     positional arguments:
-      DESC_FILE             run description YAML file
-      RESULTS_DIR           directory to store results into
+      DESC_FILE     run description YAML file
+      RESULTS_DIR   directory to store results into
 
-    optional arguments:
+    options:
       -h, --help            show this help message and exit
-      --cedar-broadwell     Use broadwell (32 cores/node) nodes on cedar instead
-                            of the
-                            default skylake (48 cores/node) nodes.
-      --deflate             Include "salishsea deflate" command in the bash
-                            script.
+      --cores-per-node CORES_PER_NODE
+                            Number of cores/node to use in PBS or SBATCH directives.
+                            Use this option to override the default cores/node that are
+                            specified in the code for each HPC cluster.
+      --cpu-arch CPU_ARCH
+                            CPU architecture to use in PBS or SBATCH directives.
+                            Use this to override the default CPU architecture on
+                            HPC clusters that have more than one type of CPU;
+                            e.g. sockeye (cascadelake is default, skylake is alternative)
+                            or cedar (skylake is default, broadwell is alternative).
+                            This option must be used in conjunction with --core-per-node.
+      --deflate
+                            Include "salishsea deflate" command in the bash script.
                             Use this option, or the --separate-deflate option
                             if you are *not* using on-the-fly deflation in XIOS-2;
                             i.e. you are using more than 1 XIOS-2 process and/or
-                            do not have the compression_level="4" attribute set in
-                            all of
+                            do not have the compression_level="4" attribute set in all of
                             the file_group definitions in your file_def.xml file.
       --max-deflate-jobs MAX_DEFLATE_JOBS
                             Maximum number of concurrent sub-processes to
@@ -90,25 +101,22 @@ For example:
                             Suppress checking of the initial conditions link.
                             Useful if you are submitting a job to wait on a
                             previous job
-      --no-submit           Prepare the temporary run directory, and the bash
-                            script to execute
-                            the NEMO run, but don't submit the run to the queue.
-                            This is useful during development runs when you want
-                            to hack on the
-                            bash script and/or use the same temporary run
-                            directory more than
-                            once.
-      --separate-deflate    Produce separate bash scripts to deflate the run
-                            results and submit
-                            them to run as serial jobs after the NEMO run finishes
-                            via the
-                            queue manager's job chaining feature.
-      --waitjob WAITJOB     Make this job wait for to start until the successful
-                            completion of
-                            WAITJOB. WAITJOB is the queue job number of the job to
-                            wait for.
-      -q, --quiet           Don't show the run directory path or job submission
-                            message.
+      --no-submit
+                            Prepare the temporary run directory, and the bash script
+                            to execute the NEMO run, but don't submit the run to the queue.
+                            This is useful during development runs when you want to
+                            hack on the bash script and/or use the same temporary run
+                            directory more than once.
+      --separate-deflate
+                            Produce separate bash scripts to deflate the run results
+                            and submit them to run as serial jobs after the NEMO run
+                            finishes via the queue manager's job chaining feature.
+      --waitjob WAITJOB
+                            Make this job wait for to start until the successful
+                            completion of WAITJOB. WAITJOB is the queue job number of
+                            the job to wait for.
+      -q, --quiet
+                            Don't show the run directory path or job submission message.
 
 You can check what version of :program:`salishsea` you have installed with:
 
@@ -124,37 +132,45 @@ You can check what version of :program:`salishsea` you have installed with:
 
 The :command:`run` sub-command prepares,
 executes,
-and gathers the results from the Salish Sea NEMO run described in the specified run description file.
+and gathers the results from the Salish Sea NEMO run described in the specified run
+description file.
 The results are gathered in the specified results directory.
 
-::
+.. code-block:: text
 
-    usage: salishsea run [-h] [--cedar-broadwell] [--deflate]
-                         [--max-deflate-jobs MAX_DEFLATE_JOBS]
+    usage: salishsea run [-h] [--cores-per-node CORES_PER_NODE] [--cpu-arch CPU_ARCH]
+                         [--deflate] [--max-deflate-jobs MAX_DEFLATE_JOBS]
                          [--nocheck-initial-conditions] [--no-submit]
                          [--separate-deflate] [--waitjob WAITJOB] [-q]
                          DESC_FILE RESULTS_DIR
 
     Prepare, execute, and gather the results from a Salish Sea NEMO-3.6 run
-    described in DESC_FILE. The results files from the run are gathered in
-    RESULTS_DIR. If RESULTS_DIR does not exist it will be created.
+    described in DESC_FILE. The results files from the run are gathered in RESULTS_DIR.
+    If RESULTS_DIR does not exist it will be created.
 
     positional arguments:
-      DESC_FILE             run description YAML file
-      RESULTS_DIR           directory to store results into
+      DESC_FILE     run description YAML file
+      RESULTS_DIR   directory to store results into
 
-    optional arguments:
+    options:
       -h, --help            show this help message and exit
-      --cedar-broadwell     Use broadwell (32 cores/node) nodes on cedar instead
-                            of the
-                            default skylake (48 cores/node) nodes.
-      --deflate             Include "salishsea deflate" command in the bash
-                            script.
+      --cores-per-node CORES_PER_NODE
+                            Number of cores/node to use in PBS or SBATCH directives.
+                            Use this option to override the default cores/node that are
+                            specified in the code for each HPC cluster.
+      --cpu-arch CPU_ARCH
+                            CPU architecture to use in PBS or SBATCH directives.
+                            Use this to override the default CPU architecture on
+                            HPC clusters that have more than one type of CPU;
+                            e.g. sockeye (cascadelake is default, skylake is alternative)
+                            or cedar (skylake is default, broadwell is alternative).
+                            This option must be used in conjunction with --core-per-node.
+      --deflate
+                            Include "salishsea deflate" command in the bash script.
                             Use this option, or the --separate-deflate option
                             if you are *not* using on-the-fly deflation in XIOS-2;
                             i.e. you are using more than 1 XIOS-2 process and/or
-                            do not have the compression_level="4" attribute set in
-                            all of
+                            do not have the compression_level="4" attribute set in all of
                             the file_group definitions in your file_def.xml file.
       --max-deflate-jobs MAX_DEFLATE_JOBS
                             Maximum number of concurrent sub-processes to
@@ -163,25 +179,22 @@ The results are gathered in the specified results directory.
                             Suppress checking of the initial conditions link.
                             Useful if you are submitting a job to wait on a
                             previous job
-      --no-submit           Prepare the temporary run directory, and the bash
-                            script to execute
-                            the NEMO run, but don't submit the run to the queue.
-                            This is useful during development runs when you want
-                            to hack on the
-                            bash script and/or use the same temporary run
-                            directory more than
-                            once.
-      --separate-deflate    Produce separate bash scripts to deflate the run
-                            results and submit
-                            them to run as serial jobs after the NEMO run finishes
-                            via the
-                            queue manager's job chaining feature.
-      --waitjob WAITJOB     Make this job wait for to start until the successful
-                            completion of
-                            WAITJOB. WAITJOB is the queue job number of the job to
-                            wait for.
-      -q, --quiet           Don't show the run directory path or job submission
-                            message.
+      --no-submit
+                            Prepare the temporary run directory, and the bash script
+                            to execute the NEMO run, but don't submit the run to the queue.
+                            This is useful during development runs when you want to
+                            hack on the bash script and/or use the same temporary run
+                            directory more than once.
+      --separate-deflate
+                            Produce separate bash scripts to deflate the run results
+                            and submit them to run as serial jobs after the NEMO run
+                            finishes via the queue manager's job chaining feature.
+      --waitjob WAITJOB
+                            Make this job wait for to start until the successful
+                            completion of WAITJOB. WAITJOB is the queue job number of
+                            the job to wait for.
+      -q, --quiet
+                            Don't show the run directory path or job submission message.
 
 The path to the run directory,
 and the response from the job queue manager

--- a/docs/subcommands.rst
+++ b/docs/subcommands.rst
@@ -269,22 +269,25 @@ Example:
 :kbd:`prepare` Sub-command
 ==========================
 
-The :command:`prepare` sub-command sets up a run directory from which to execute the Salish Sea NEMO run described in the specifed run description,
-and IOM server definitions files::
+The :command:`prepare` sub-command sets up a run directory from which to execute the
+Salish Sea NEMO run described in the specified run description,
+and IOM server definitions files:
 
-  usage: salishsea prepare [-h] [--nemo3.4] [-q] DESC_FILE
+.. code-block:: text
 
-  Set up the Salish Sea NEMO described in DESC_FILE and print the path to the
-  run directory.
+    usage: salishsea prepare [-h] [--nemo3.4] [-q] DESC_FILE
 
-  positional arguments:
-    DESC_FILE    run description YAML file
+    Set up the Salish Sea NEMO described in DESC_FILE and print the path to the
+    run directory.
 
-  optional arguments:
-    -h, --help   show this help message and exit
-    --nemo3.4    Prepare a NEMO-3.4 run; the default is to prepare a NEMO-3.6
-                 run
-    -q, --quiet  don't show the run directory path on completion
+    positional arguments:
+      DESC_FILE    run description YAML file
+
+    optional arguments:
+      -h, --help   show this help message and exit
+      --nemo3.4    Prepare a NEMO-3.4 run; the default is to prepare a NEMO-3.6
+                   run
+      -q, --quiet  don't show the run directory path on completion
 
 See the :ref:`RunDescriptionFileStructure` section for details of the run description file.
 
@@ -453,19 +456,20 @@ The restart files are moved to the last run day's directory.
 
 .. _file_def_dailysplit.xml: https://github.com/SalishSeaCast/SS-run-sets/blob/master/v201905/hindcast/file_def_dailysplit.xml
 
-::
+.. code-block:: text
 
-  usage: salishsea split-results [-h] [-q] SOURCE_DIR
+    usage: salishsea split-results [-h] [-q] SOURCE_DIR
 
-  Split the results of the multi-day SalishSeaCast NEMO model run in SOURCE_DIR
-  into daily results directories.
+    Split the results of the multi-day SalishSeaCast NEMO model run in SOURCE_DIR
+    into daily results directories.
 
-  positional arguments:
-    SOURCE_DIR   Multi-day results directory to split into daily directories
+    positional arguments:
+      SOURCE_DIR   Multi-day results directory to split into daily directories
 
-  optional arguments:
-    -h, --help   show this help message and exit
-    -q, --quiet  Don't show progess messages.
+    optional arguments:
+      -h, --help   show this help message and exit
+      -q, --quiet  Don't show progess messages.
 
 If the :command:`split-results` sub-command prints an error message,
-you can get a Python traceback containing more information about the error by re-running the command with the :kbd:`--debug` flag.
+you can get a Python traceback containing more information about the error by re-running
+the command with the :kbd:`--debug` flag.

--- a/salishsea_cmd/run.py
+++ b/salishsea_cmd/run.py
@@ -93,15 +93,6 @@ class Run(cliff.command.Command):
             """,
         )
         parser.add_argument(
-            "--cedar-broadwell",
-            dest="cedar_broadwell",
-            action="store_true",
-            help="""
-            Use broadwell (32 cores/node) nodes on cedar instead of the 
-            default skylake (48 cores/node) nodes.
-            """,
-        )
-        parser.add_argument(
             "--cpu-arch",
             dest="cpu_arch",
             default="",
@@ -197,7 +188,6 @@ class Run(cliff.command.Command):
             parsed_args.results_dir,
             cores_per_node=parsed_args.cores_per_node,
             cpu_arch=parsed_args.cpu_arch,
-            cedar_broadwell=parsed_args.cedar_broadwell,
             deflate=parsed_args.deflate,
             max_deflate_jobs=parsed_args.max_deflate_jobs,
             nocheck_init=parsed_args.nocheck_init,
@@ -215,7 +205,6 @@ def run(
     results_dir,
     cores_per_node="",
     cpu_arch="",
-    cedar_broadwell=False,
     deflate=False,
     max_deflate_jobs=4,
     nocheck_init=False,
@@ -250,8 +239,6 @@ def run(
                                e.g. sockeye (cascadelake is default, skylake is alternative)
                                or cedar (skylake is default, broadwell is alternative).
                                This option must be used in conjunction with --core-per-node.
-
-    :param boolean cedar_broadwell: Use broadwell (32 cores/node) on cedar.
 
     :param boolean deflate: Include "salishsea deflate" command in the bash
                             script.
@@ -328,7 +315,6 @@ def run(
                 results_dir,
                 cores_per_node,
                 cpu_arch,
-                cedar_broadwell,
                 deflate,
                 max_deflate_jobs,
                 separate_deflate,
@@ -525,7 +511,6 @@ def _build_tmp_run_dir(
     results_dir,
     cores_per_node,
     cpu_arch,
-    cedar_broadwell,
     deflate,
     max_deflate_jobs,
     separate_deflate,
@@ -553,7 +538,6 @@ def _build_tmp_run_dir(
         run_dir,
         deflate,
         separate_deflate,
-        cedar_broadwell,
         cores_per_node,
         cpu_arch,
     )
@@ -641,7 +625,6 @@ def _build_batch_script(
     run_dir,
     deflate,
     separate_deflate,
-    cedar_broadwell,
     cores_per_node,
     cpu_arch,
 ):
@@ -676,9 +659,6 @@ def _build_batch_script(
                                      the run results and qsub them to run as
                                      serial jobs after the NEMO run finishes.
 
-    :param boolean cedar_broadwell: Use broadwell (32 cores/node) nodes on
-                                    cedar.
-
     :param str cores_per_node: Number of cores/node to use in PBS or SBATCH directives.
 
     :param str cpu_arch: CPU architecture to use in PBS or SBATCH directives.
@@ -706,7 +686,6 @@ def _build_batch_script(
                         nemo_processors + xios_processors,
                         procs_per_node,
                         cpu_arch,
-                        cedar_broadwell,
                         email,
                         results_dir,
                     )
@@ -774,7 +753,6 @@ def _sbatch_directives(
     n_processors,
     procs_per_node,
     cpu_arch,
-    cedar_broadwell,
     email,
     results_dir,
     mem="0",
@@ -797,9 +775,6 @@ def _sbatch_directives(
 
     :param str cpu_arch: CPU architecture to use in PBS or SBATCH directives.
 
-    :param boolean cedar_broadwell: Use broadwell (32 cores/node) nodes on
-                                    cedar.
-
     :param str email: Email address to send job begin, end & abort
                       notifications to.
 
@@ -818,7 +793,6 @@ def _sbatch_directives(
     :rtype: Unicode str
     """
     run_id = get_run_desc_value(run_desc, ("run_id",))
-    constraint = "broadwell" if SYSTEM == "cedar" and cedar_broadwell else "skylake"
     nodes = math.ceil(n_processors / procs_per_node)
     mem = {"beluga": "92G", "cedar": "0", "graham": "0"}.get(SYSTEM, mem)
     if deflate:

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -56,7 +56,6 @@ class TestParser:
         assert parsed_args.results_dir == Path("baz")
         assert parsed_args.cores_per_node == ""
         assert parsed_args.cpu_arch == ""
-        assert not parsed_args.cedar_broadwell
         assert not parsed_args.deflate
         assert parsed_args.max_deflate_jobs == 4
         assert not parsed_args.nocheck_init
@@ -68,7 +67,6 @@ class TestParser:
     @pytest.mark.parametrize(
         "flag, attr",
         [
-            ("--cedar-broadwell", "cedar_broadwell"),
             ("--deflate", "deflate"),
             ("--nocheck-initial-conditions", "nocheck_init"),
             ("--no-submit", "no_submit"),
@@ -94,7 +92,6 @@ class TestTakeAction:
             results_dir="results dir",
             cores_per_node="",
             cpu_arch="",
-            cedar_broadwell=False,
             deflate=False,
             max_deflate_jobs=4,
             nocheck_init=False,
@@ -109,7 +106,6 @@ class TestTakeAction:
             "results dir",
             cores_per_node="",
             cpu_arch="",
-            cedar_broadwell=False,
             deflate=False,
             max_deflate_jobs=4,
             nocheck_init=False,
@@ -1757,7 +1753,6 @@ class TestBuildTmpRunDir:
             Path("results_dir"),
             cores_per_node="",
             cpu_arch="",
-            cedar_broadwell=False,
             deflate=False,
             max_deflate_jobs=4,
             separate_deflate=False,
@@ -1793,7 +1788,6 @@ class TestBuildTmpRunDir:
             Path("results_dir"),
             cores_per_node="",
             cpu_arch="",
-            cedar_broadwell=False,
             deflate=False,
             max_deflate_jobs=4,
             separate_deflate=False,
@@ -1830,7 +1824,6 @@ class TestBuildTmpRunDir:
             Path("results_dir"),
             cores_per_node="",
             cpu_arch="",
-            cedar_broadwell=False,
             deflate=False,
             max_deflate_jobs=4,
             separate_deflate=True,
@@ -1992,7 +1985,6 @@ class TestBuildBatchScript:
                 run_dir=Path("tmp_run_dir"),
                 deflate=deflate,
                 separate_deflate=False,
-                cedar_broadwell=False,
                 cores_per_node="",
                 cpu_arch="",
             )
@@ -2082,10 +2074,10 @@ class TestBuildBatchScript:
         assert script == expected
 
     @pytest.mark.parametrize(
-        "cedar_broadwell, cpu_arch, nodes, cores_per_node, mem, deflate",
-        [(True, "broadwell", 2, "32", "0", True), (False, "skylake", 1, "48", "0", True)],
+        "cpu_arch, nodes, cores_per_node, mem, deflate",
+        [("broadwell", 2, "32", "0", True), ("skylake", 1, "48", "0", True)],
     )
-    def test_cedar(self, cedar_broadwell, cpu_arch, nodes, cores_per_node, mem, deflate):
+    def test_cedar(self, cpu_arch, nodes, cores_per_node, mem, deflate):
         desc_file = StringIO(
             "run_id: foo\n" "walltime: 01:02:03\n" "email: me@example.com"
         )
@@ -2101,7 +2093,6 @@ class TestBuildBatchScript:
                 run_dir=Path("tmp_run_dir"),
                 deflate=deflate,
                 separate_deflate=False,
-                cedar_broadwell=cedar_broadwell,
                 cores_per_node=cores_per_node,
                 cpu_arch=cpu_arch,
             )
@@ -2210,7 +2201,6 @@ class TestBuildBatchScript:
                 run_dir=Path("tmp_run_dir"),
                 deflate=deflate,
                 separate_deflate=False,
-                cedar_broadwell=False,
                 cores_per_node="",
                 cpu_arch="",
             )
@@ -2319,7 +2309,6 @@ class TestBuildBatchScript:
                 run_dir=Path("tmp_run_dir"),
                 deflate=deflate,
                 separate_deflate=False,
-                cedar_broadwell=False,
                 cores_per_node="",
                 cpu_arch="",
             )
@@ -2435,7 +2424,6 @@ class TestBuildBatchScript:
                 run_dir=Path("tmp_run_dir"),
                 deflate=deflate,
                 separate_deflate=False,
-                cedar_broadwell=False,
                 cores_per_node="",
                 cpu_arch="",
             )
@@ -2544,7 +2532,6 @@ class TestBuildBatchScript:
                 run_dir=Path("tmp_run_dir"),
                 deflate=deflate,
                 separate_deflate=False,
-                cedar_broadwell=False,
                 cores_per_node="",
                 cpu_arch="",
             )
@@ -2652,7 +2639,6 @@ class TestBuildBatchScript:
                 run_dir=Path("tmp_run_dir"),
                 deflate=deflate,
                 separate_deflate=False,
-                cedar_broadwell=False,
                 cores_per_node=cores_per_node,
                 cpu_arch=cpu_arch,
             )
@@ -2760,7 +2746,6 @@ class TestBuildBatchScript:
                     run_dir=Path("tmp_run_dir"),
                     deflate=False,
                     separate_deflate=False,
-                    cedar_broadwell=False,
                     cores_per_node="",
                     cpu_arch="",
                 )
@@ -2780,7 +2765,6 @@ class TestSbatchDirectives:
                 n_processors=43,
                 procs_per_node=40,
                 cpu_arch="",
-                cedar_broadwell=False,
                 email="me@example.com",
                 results_dir=Path("foo"),
             )
@@ -2801,14 +2785,14 @@ class TestSbatchDirectives:
         assert m_logger.info.called
 
     @pytest.mark.parametrize(
-        "system, account, cedar_broadwell, cpu_arch, nodes, procs_per_node, mem",
+        "system, account, cpu_arch, nodes, procs_per_node, mem",
         [
-            ("cedar", "rrg-allen", True, "broadwell", 2, 32, "0"),
-            ("cedar", "rrg-allen", False, "skylake", 1, 48, "0"),
+            ("cedar", "rrg-allen", "broadwell", 2, 32, "0"),
+            ("cedar", "rrg-allen", "skylake", 1, 48, "0"),
         ],
     )
     def test_cedar_sbatch_directives(
-        self, m_logger, system, account, cedar_broadwell, cpu_arch, nodes, procs_per_node, mem
+        self, m_logger, system, account, cpu_arch, nodes, procs_per_node, mem
     ):
         desc_file = StringIO("run_id: foo\n" "walltime: 01:02:03\n")
         run_desc = yaml.safe_load(desc_file)
@@ -2818,7 +2802,6 @@ class TestSbatchDirectives:
                 43,
                 procs_per_node=procs_per_node,
                 cpu_arch=cpu_arch,
-                cedar_broadwell=cedar_broadwell,
                 email="me@example.com",
                 results_dir=Path("foo"),
             )
@@ -2850,7 +2833,6 @@ class TestSbatchDirectives:
                 n_processors=43,
                 procs_per_node=32,
                 cpu_arch="",
-                cedar_broadwell=False,
                 email="me@example.com",
                 results_dir=Path("foo"),
             )
@@ -2889,7 +2871,6 @@ class TestSbatchDirectives:
                 43,
                 procs_per_node=procs_per_node,
                 cpu_arch="",
-                cedar_broadwell=False,
                 email="me@example.com",
                 results_dir=Path("foo"),
             )


### PR DESCRIPTION
Replacement for --cedar-broadwell flag because we need to be able to specify cores/node 
and CPU architecture for sockeye now too.