### PR TITLE
Update to Python 3.11

### DIFF
--- a/.github/workflows/docs-linkcheck.yaml
+++ b/.github/workflows/docs-linkcheck.yaml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         # Need to specify Python version here because we use test env which gets its
         # Python version via matrix
-        python-version: ['3.10']
+        python-version: ['3.11']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pytest-coverage.yaml
+++ b/.github/workflows/pytest-coverage.yaml
@@ -30,12 +30,6 @@ jobs:
            environment-file: envs/environment-test.yaml
            activate-environment: salishsea-cmd-test
 
-      - name: Install packages
-        shell: bash -l {0}
-        run: |
-          python3 -m pip install --src $GITHUB_WORKSPACE/../vcs_pkgs/ --editable git+https://github.com/SalishSeaCast/NEMO-Cmd.git#egg=NEMO-Cmd
-          python3 -m pip install --editable $GITHUB_WORKSPACE
-
       - name: pytest package with coverage
         shell: bash -l {0}
         run: |

--- a/.github/workflows/pytest-coverage.yaml
+++ b/.github/workflows/pytest-coverage.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
       - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ SalishSeaCast NEMO Command Processor
     :target: https://www.apache.org/licenses/LICENSE-2.0
     :alt: Licensed under the Apache License, Version 2.0
 .. image:: https://img.shields.io/badge/python-3.5+-blue.svg
-    :target: https://docs.python.org/3.10/
+    :target: https://docs.python.org/3.11/
     :alt: Python Version
 .. image:: https://img.shields.io/badge/version%20control-git-blue.svg?logo=github
     :target: https://github.com/SalishSeaCast/SalishSeaCmd

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -26,7 +26,7 @@
     :target: https://www.apache.org/licenses/LICENSE-2.0
     :alt: Licensed under the Apache License, Version 2.0
 .. image:: https://img.shields.io/badge/python-3.5+-blue.svg
-    :target: https://docs.python.org/3.10/
+    :target: https://docs.python.org/3.11/
     :alt: Python Version
 .. image:: https://img.shields.io/badge/version%20control-git-blue.svg?logo=github
     :target: https://github.com/SalishSeaCast/SalishSeaCmd
@@ -60,10 +60,10 @@ Python Versions
 ===============
 
 .. image:: https://img.shields.io/badge/python-3.5+-blue.svg
-    :target: https://docs.python.org/3.10/
+    :target: https://docs.python.org/3.11/
     :alt: Python Version
 
-The :kbd:`SalishSeaCmd` package is developed and tested using `Python`_ 3.10.
+The :kbd:`SalishSeaCmd` package is developed and tested using `Python`_ 3.11.
 It is recommended that the package be used under Python>=3.8.
 However,
 the package must also run under `Python`_ 3.5 for use on the Westgrid :kbd:`orcinus` HPC platform.
@@ -312,7 +312,7 @@ The output looks something like::
   (line   91) ok        https://salishsea-meopar-docs.readthedocs.io/en/latest/code-notes/salishsea-nemo/land-processor-elimination/index.html#landprocessorelimination
   (line   53) ok        https://calver.org/
   writing output... [ 30%] development
-  (line   21) ok        https://docs.python.org/3.10/
+  (line   21) ok        https://docs.python.org/3.11/
   (line   21) ok        https://black.readthedocs.io/en/stable/
   (line   21) ok        https://salishseacmd.readthedocs.io/en/latest/
   (line   21) ok        https://codecov.io/gh/SalishSeaCast/SalishSeaCmd

--- a/envs/environment-dev.yaml
+++ b/envs/environment-dev.yaml
@@ -9,10 +9,10 @@
 #   (salishsea-cmd)$ pip install --editable NEMO-Cmd/
 #   (salishsea-cmd)$ pip install --editable SalishSeaCmd/
 #
-# The environment will also include all of the tools used to develop,
+# The environment will also include all the tools used to develop,
 # test, and document the SalishSeaCmd package.
 #
-# See the requirements.txt file for an exhaustive list of all of the
+# See the requirements.txt file for an exhaustive list of all the
 # packages installed in the environment and their versions used in
 # recent development.
 
@@ -28,7 +28,7 @@ dependencies:
   - f90nml
   - gitpython
   - pip
-  - python=3.10
+  - python=3.11
   - pyyaml
 
   # For coding style

--- a/envs/environment-rtd.yaml
+++ b/envs/environment-rtd.yaml
@@ -11,7 +11,7 @@ channels:
   - nodefaults
 
 dependencies:
-  - python=3.10
+  - python=3.11
 
   # RTD packages
   - mock

--- a/envs/environment-test.yaml
+++ b/envs/environment-test.yaml
@@ -31,3 +31,7 @@ dependencies:
 
     # For unit tests
     - pytest-randomly
+
+    # editable install of NEMO-Cmd & SalishSeaCmd packages
+    - --editable git+https://github.com/SalishSeaCast/NEMO-Cmd.git#egg=NEMO-Cmd
+    - --editable ../

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+# Don't try to collect tests in the envs/ tree because environment-test.yaml installs
+# NEMO-Cmd from GitHub in envs/src/ and we don't want to collect its test suite
+norecursedirs = envs

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Operating System :: POSIX :: Linux
     Operating System :: Unix
     Environment :: Console


### PR DESCRIPTION
- [x] Add Python 3.11 to GHA pytest-coverage workflow so that we can use the workflow to test whether all the packages SalishSeaCmd depends on have been updated to support Python 3.11.
- [ ] Change sphinx-linkcheck workflow to Python 3.11
- [ ] Change to Python 3.11 for package development