### PR TITLE
Add sphinx-notfound-page extension to docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,6 +37,7 @@ release = version
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "notfound.extension",
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
     "sphinx.ext.todo",

--- a/envs/environment-dev.yaml
+++ b/envs/environment-dev.yaml
@@ -42,6 +42,7 @@ dependencies:
   # For documentation
   - sphinx
   - sphinx_rtd_theme
+  - sphinx-notfound-page
 
   - pip:
     - python-hglib

--- a/envs/environment-rtd.yaml
+++ b/envs/environment-rtd.yaml
@@ -19,6 +19,7 @@ dependencies:
   - pillow
   - sphinx
   - sphinx_rtd_theme
+  - sphinx-notfound-page
 
   - pip:
     - recommonmark

--- a/envs/environment-test.yaml
+++ b/envs/environment-test.yaml
@@ -25,6 +25,7 @@ dependencies:
   # For documentation links checking
   - sphinx
   - sphinx_rtd_theme
+  - sphinx-notfound-page
 
   - pip:
     - python-hglib

--- a/envs/requirements.txt
+++ b/envs/requirements.txt
@@ -92,6 +92,7 @@ smmap==3.0.5
 sniffio==1.3.0
 snowballstemmer==2.2.0
 Sphinx==5.3.0
+sphinx-notfound-page==0.8.3
 sphinx-rtd-theme==1.1.1
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2


### PR DESCRIPTION
Ensures that static assets load in the event of a 404 for a better UX. Facilitates future customization of 404 page.