### PR TITLE
Apr-2023 updates for running on graham, beluga & cedar

### DIFF
--- a/salishsea_cmd/run.py
+++ b/salishsea_cmd/run.py
@@ -951,15 +951,15 @@ def _modules():
         "beluga": textwrap.dedent(
             """\
             module load StdEnv/2020
-            module load netcdf-fortran-mpi/4.5.2
-            module load python/3.9.6
+            module load netcdf-fortran-mpi/4.6.0
+            module load python/3.11.2
             """
         ),
         "cedar": textwrap.dedent(
             """\
             module load StdEnv/2020
-            module load netcdf-fortran-mpi/4.5.2
-            module load python/3.9.6
+            module load netcdf-fortran-mpi/4.6.0
+            module load python/3.11.2
             """
         ),
         "delta": textwrap.dedent(
@@ -970,8 +970,8 @@ def _modules():
         "graham": textwrap.dedent(
             """\
             module load StdEnv/2020
-            module load netcdf-fortran-mpi/4.5.2
-            module load python/3.9.6
+            module load netcdf-fortran-mpi/4.6.0
+            module load python/3.11.2
             """
         ),
         "omega": textwrap.dedent(

--- a/salishsea_cmd/run.py
+++ b/salishsea_cmd/run.py
@@ -756,7 +756,7 @@ def _sbatch_directives(
         account = get_run_desc_value(run_desc, ("account",), fatal=False)
         sbatch_directives += f"#SBATCH --account={account}\n"
     except KeyError:
-        account = "rrg-allen" if SYSTEM in {"beluga", "cedar"} else "def-allen"
+        account = "rrg-allen" if SYSTEM in {"graham"} else "def-allen"
         sbatch_directives += f"#SBATCH --account={account}\n"
         log.info(
             f"No account found in run description YAML file, "

--- a/salishsea_cmd/run.py
+++ b/salishsea_cmd/run.py
@@ -952,14 +952,12 @@ def _modules():
             """\
             module load StdEnv/2020
             module load netcdf-fortran-mpi/4.6.0
-            module load python/3.11.2
             """
         ),
         "cedar": textwrap.dedent(
             """\
             module load StdEnv/2020
             module load netcdf-fortran-mpi/4.6.0
-            module load python/3.11.2
             """
         ),
         "delta": textwrap.dedent(
@@ -971,7 +969,6 @@ def _modules():
             """\
             module load StdEnv/2020
             module load netcdf-fortran-mpi/4.6.0
-            module load python/3.11.2
             """
         ),
         "omega": textwrap.dedent(

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1983,7 +1983,6 @@ class TestBuildBatchScript:
 
             module load StdEnv/2020
             module load netcdf-fortran-mpi/4.6.0
-            module load python/3.11.2
 
             mkdir -p ${RESULTS_DIR}
             cd ${WORK_DIR}
@@ -2090,7 +2089,6 @@ class TestBuildBatchScript:
 
             module load StdEnv/2020
             module load netcdf-fortran-mpi/4.6.0
-            module load python/3.11.2
 
             mkdir -p ${RESULTS_DIR}
             cd ${WORK_DIR}
@@ -2195,7 +2193,6 @@ class TestBuildBatchScript:
 
             module load StdEnv/2020
             module load netcdf-fortran-mpi/4.6.0
-            module load python/3.11.2
 
             mkdir -p ${RESULTS_DIR}
             cd ${WORK_DIR}
@@ -3196,7 +3193,6 @@ class TestModules:
             """\
             module load StdEnv/2020
             module load netcdf-fortran-mpi/4.6.0
-            module load python/3.11.2
             """
         )
         assert modules == expected

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1926,7 +1926,7 @@ class TestBuildBatchScript:
     """Unit test for _build_batch_script() function."""
 
     @pytest.mark.parametrize(
-        "account, deflate", [("rrg-allen", True), ("rrg-allen", False)]
+        "account, deflate", [("def-allen", True), ("def-allen", False)]
     )
     def test_beluga(self, account, deflate):
         desc_file = StringIO(
@@ -2065,7 +2065,7 @@ class TestBuildBatchScript:
             #SBATCH --time=1:02:03
             #SBATCH --mail-user=me@example.com
             #SBATCH --mail-type=ALL
-            #SBATCH --account=rrg-allen
+            #SBATCH --account=def-allen
             # stdout and stderr file paths/names
             #SBATCH --output=results_dir/stdout
             #SBATCH --error=results_dir/stderr
@@ -2138,7 +2138,7 @@ class TestBuildBatchScript:
         assert script == expected
 
     @pytest.mark.parametrize(
-        "account, deflate", [("def-allen", True), ("def-allen", False)]
+        "account, deflate", [("rrg-allen", True), ("rrg-allen", False)]
     )
     def test_graham(self, account, deflate):
         desc_file = StringIO(
@@ -2737,7 +2737,7 @@ class TestSbatchDirectives:
             "#SBATCH --time=1:02:03\n"
             "#SBATCH --mail-user=me@example.com\n"
             "#SBATCH --mail-type=ALL\n"
-            "#SBATCH --account=rrg-allen\n"
+            "#SBATCH --account=def-allen\n"
             "# stdout and stderr file paths/names\n"
             "#SBATCH --output=foo/stdout\n"
             "#SBATCH --error=foo/stderr\n"
@@ -2748,8 +2748,8 @@ class TestSbatchDirectives:
     @pytest.mark.parametrize(
         "system, account, cpu_arch, nodes, procs_per_node, mem",
         [
-            ("cedar", "rrg-allen", "broadwell", 2, 32, "0"),
-            ("cedar", "rrg-allen", "skylake", 1, 48, "0"),
+            ("cedar", "def-allen", "broadwell", 2, 32, "0"),
+            ("cedar", "def-allen", "skylake", 1, 48, "0"),
         ],
     )
     def test_cedar_sbatch_directives(
@@ -2803,7 +2803,7 @@ class TestSbatchDirectives:
             "#SBATCH --time=1:02:03\n"
             "#SBATCH --mail-user=me@example.com\n"
             "#SBATCH --mail-type=ALL\n"
-            "#SBATCH --account=def-allen\n"
+            "#SBATCH --account=rrg-allen\n"
             "# stdout and stderr file paths/names\n"
             "#SBATCH --output=foo/stdout\n"
             "#SBATCH --error=foo/stderr\n"

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1982,8 +1982,8 @@ class TestBuildBatchScript:
             GATHER="${HOME}/.local/bin/salishsea gather"
 
             module load StdEnv/2020
-            module load netcdf-fortran-mpi/4.5.2
-            module load python/3.9.6
+            module load netcdf-fortran-mpi/4.6.0
+            module load python/3.11.2
 
             mkdir -p ${RESULTS_DIR}
             cd ${WORK_DIR}
@@ -2089,8 +2089,8 @@ class TestBuildBatchScript:
             GATHER="${HOME}/.local/bin/salishsea gather"
 
             module load StdEnv/2020
-            module load netcdf-fortran-mpi/4.5.2
-            module load python/3.9.6
+            module load netcdf-fortran-mpi/4.6.0
+            module load python/3.11.2
 
             mkdir -p ${RESULTS_DIR}
             cd ${WORK_DIR}
@@ -2194,8 +2194,8 @@ class TestBuildBatchScript:
             GATHER="${HOME}/.local/bin/salishsea gather"
 
             module load StdEnv/2020
-            module load netcdf-fortran-mpi/4.5.2
-            module load python/3.9.6
+            module load netcdf-fortran-mpi/4.6.0
+            module load python/3.11.2
 
             mkdir -p ${RESULTS_DIR}
             cd ${WORK_DIR}
@@ -3195,8 +3195,8 @@ class TestModules:
         expected = textwrap.dedent(
             """\
             module load StdEnv/2020
-            module load netcdf-fortran-mpi/4.5.2
-            module load python/3.9.6
+            module load netcdf-fortran-mpi/4.6.0
+            module load python/3.11.2
             """
         )
         assert modules == expected


### PR DESCRIPTION
Update module load for NEMO runs to:
```
netcdf-fortran-mpi/4.6.0
```

With our change to using a `salishsea-cmd `miniconda env on HPC clusters in
combination with the `--user` install strategy, the `SalishSeaNEMO.sh` script no
longer needs to load a Python module because the Python interpreter is provided
by the `#!` in `$HOME/.local/bin/salishsea`.

Default account on graham is `rrg-allen`; on other clusters it's `def-allen`.