### PR TITLE
Add Hatch wheel build target to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,5 +76,8 @@ source = [ "salishsea_cmd", "tests"]
 show_missing = true
 
 
+[tool.hatch.build.targets.wheel]
+packages = ["salishsea_cmd"]
+
 [tool.hatch.version]
 path = "salishsea_cmd/__about__.py"


### PR DESCRIPTION
Hatchling 1.19.0 changed the package identification heuristics such that an explicit declaration of the code directory tree to build the wheel for installation from is now required.