### PR TITLE
Add CODECOV_TOKEN to GHA pytest-with-coverage workflow

### DIFF
--- a/.github/workflows/pytest-with-coverage.yaml
+++ b/.github/workflows/pytest-with-coverage.yaml
@@ -21,3 +21,5 @@ jobs:
       python-version: ${{ matrix.python-version }}
       conda-env-file: envs/environment-test.yaml
       conda-env-name: salishsea-cmd-test
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
A CODECOV_TOKEN has been added to the pytest-with-coverage.yaml file in the .github workflows. This token is necessary for uploading coverage reports to codecov, and for codecov to add test coverage report comments to pull requests.