### PR TITLE
Update badge tables in README and dev docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,51 +2,50 @@
 SalishSeaCast NEMO Command Processor
 ************************************
 
-+------------------------------+---------------------------------------------------------------------------------------------------------------------+
-|  **Continuous Integration**  |  .. image:: https://github.com/SalishSeaCast/SalishSeaCmd/actions/workflows/pytest-with-coverage.yaml/badge.svg     |
-|                              |       :target: https://github.com/SalishSeaCast/SalishSeaCmd/actions?query=workflow:pytest-with-coverage            |
-|                              |       :alt: Pytest with Coverage Status                                                                             |
-|                              |  .. image:: https://codecov.io/gh/SalishSeaCast/SalishSeaCmd/branch/main/graph/badge.svg                            |
-|                              |       :target: https://app.codecov.io/gh/SalishSeaCast/SalishSeaCmd                                                 |
-|                              |       :alt: Codecov Testing Coverage Report                                                                         |
-|                              |  .. image:: https://github.com/SalishSeaCast/SalishSeaCmd/actions/workflows/codeql-analysis.yaml/badge.svg          |
-|                              |      :target: https://github.com/SalishSeaCast/SalishSeaCmd/actions?query=workflow:CodeQL                           |
-|                              |      :alt: CodeQL analysis                                                                                          |
-+------------------------------+---------------------------------------------------------------------------------------------------------------------+
-|  **Documentation**           |  .. image:: https://readthedocs.org/projects/salishseacmd/badge/?version=latest                                     |
-|                              |      :target: https://salishseacmd.readthedocs.io/en/latest/                                                        |
-|                              |      :alt: Documentation Status                                                                                     |
-|                              |  .. image:: https://github.com/SalishSeaCast/SalishSeaCmd/actions/workflows/sphinx-linkcheck.yaml/badge.svg         |
-|                              |      :target: https://github.com/SalishSeaCast/SalishSeaCmd/actions?query=workflow:sphinx-linkcheck                 |
-|                              |      :alt: Sphinx linkcheck                                                                                         |
-+------------------------------+---------------------------------------------------------------------------------------------------------------------+
-|  **Package**                 |  .. image:: https://img.shields.io/github/v/release/SalishSeaCast/SalishSeaCmd?logo=github                          |
-|                              |      :target: https://github.com/SalishSeaCast/SalishSeaCmd/releases                                                |
-|                              |      :alt: Releases                                                                                                 |
-|                              |  .. image:: https://img.shields.io/badge/Python-3.11%20%7C%203.12-blue?logo=python&label=Python&logoColor=gold      |
-|                              |      :target: https://docs.python.org/3.12/                                                                         |
-|                              |      :alt: Python Version                                                                                           |
-|                              |  .. image:: https://img.shields.io/github/issues/SalishSeaCast/SalishSeaCmd?logo=github                             |
-|                              |      :target: https://github.com/SalishSeaCast/SalishSeaCmd/issues                                                  |
-|                              |      :alt: Issue Tracker                                                                                            |
-+------------------------------+---------------------------------------------------------------------------------------------------------------------+
-|  **Meta**                    |  .. image:: https://img.shields.io/badge/license-Apache%202-cb2533.svg                                              |
-|                              |      :target: https://www.apache.org/licenses/LICENSE-2.0                                                           |
-|                              |      :alt: Licensed under the Apache License, Version 2.0                                                           |
-|                              |  .. image:: https://img.shields.io/badge/version%20control-git-blue.svg?logo=github                                 |
-|                              |      :target: https://github.com/SalishSeaCast/SalishSeaCmd                                                         |
-|                              |      :alt: Git on GitHub                                                                                            |
-|                              |  .. image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white            |
-|                              |      :target: https://pre-commit.com                                                                                |
-|                              |      :alt: pre-commit                                                                                               |
-+                              +---------------------------------------------------------------------------------------------------------------------+
-|                              |  .. image:: https://img.shields.io/badge/code%20style-black-000000.svg                                              |
-|                              |      :target: https://black.readthedocs.io/en/stable/                                                               |
-|                              |      :alt: The uncompromising Python code formatter                                                                 |
-|                              |  .. image:: https://img.shields.io/badge/%F0%9F%A5%9A-Hatch-4051b5.svg                                              |
-|                              |      :target: https://github.com/pypa/hatch                                                                         |
-|                              |      :alt: Hatch project                                                                                            |
-+------------------------------+---------------------------------------------------------------------------------------------------------------------+
++----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| **Continuous Integration** | .. image:: https://github.com/SalishSeaCast/SalishSeaCmd/actions/workflows/pytest-with-coverage.yaml/badge.svg                                                                                       |
+|                            |      :target: https://github.com/SalishSeaCast/SalishSeaCmd/actions?query=workflow:pytest-with-coverage                                                                                              |
+|                            |      :alt: Pytest with Coverage Status                                                                                                                                                               |
+|                            | .. image:: https://codecov.io/gh/SalishSeaCast/SalishSeaCmd/branch/main/graph/badge.svg                                                                                                              |
+|                            |      :target: https://app.codecov.io/gh/SalishSeaCast/SalishSeaCmd                                                                                                                                   |
+|                            |      :alt: Codecov Testing Coverage Report                                                                                                                                                           |
+|                            | .. image:: https://github.com/SalishSeaCast/SalishSeaCmd/actions/workflows/codeql-analysis.yaml/badge.svg                                                                                            |
+|                            |     :target: https://github.com/SalishSeaCast/SalishSeaCmd/actions?query=workflow:CodeQL                                                                                                             |
+|                            |     :alt: CodeQL analysis                                                                                                                                                                            |
++----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| **Documentation**          | .. image:: https://readthedocs.org/projects/salishseacmd/badge/?version=latest                                                                                                                       |
+|                            |     :target: https://salishseacmd.readthedocs.io/en/latest/                                                                                                                                          |
+|                            |     :alt: Documentation Status                                                                                                                                                                       |
+|                            | .. image:: https://github.com/SalishSeaCast/SalishSeaCmd/actions/workflows/sphinx-linkcheck.yaml/badge.svg                                                                                           |
+|                            |     :target: https://github.com/SalishSeaCast/SalishSeaCmd/actions?query=workflow:sphinx-linkcheck                                                                                                   |
+|                            |     :alt: Sphinx linkcheck                                                                                                                                                                           |
++----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| **Package**                | .. image:: https://img.shields.io/github/v/release/SalishSeaCast/SalishSeaCmd?logo=github                                                                                                            |
+|                            |     :target: https://github.com/SalishSeaCast/SalishSeaCmd/releases                                                                                                                                  |
+|                            |     :alt: Releases                                                                                                                                                                                   |
+|                            | .. image:: https://img.shields.io/python/required-version-toml?tomlFilePath=https://raw.githubusercontent.com/SalishSeaCast/SalishSeaCmd/main/pyproject.toml&logo=Python&logoColor=gold&label=Python |
+|                            |      :target: https://docs.python.org/3.12/                                                                                                                                                          |
+|                            |      :alt: Python Version from PEP 621 TOML                                                                                                                                                          |
+|                            | .. image:: https://img.shields.io/github/issues/SalishSeaCast/SalishSeaCmd?logo=github                                                                                                               |
+|                            |     :target: https://github.com/SalishSeaCast/SalishSeaCmd/issues                                                                                                                                    |
+|                            |     :alt: Issue Tracker                                                                                                                                                                              |
++----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| **Meta**                   | .. image:: https://img.shields.io/badge/license-Apache%202-cb2533.svg                                                                                                                                |
+|                            |     :target: https://www.apache.org/licenses/LICENSE-2.0                                                                                                                                             |
+|                            |     :alt: Licensed under the Apache License, Version 2.0                                                                                                                                             |
+|                            | .. image:: https://img.shields.io/badge/version%20control-git-blue.svg?logo=github                                                                                                                   |
+|                            |     :target: https://github.com/SalishSeaCast/SalishSeaCmd                                                                                                                                           |
+|                            |     :alt: Git on GitHub                                                                                                                                                                              |
+|                            | .. image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white                                                                                              |
+|                            |     :target: https://pre-commit.com                                                                                                                                                                  |
+|                            |     :alt: pre-commit                                                                                                                                                                                 |
+|                            | .. image:: https://img.shields.io/badge/code%20style-black-000000.svg                                                                                                                                |
+|                            |     :target: https://black.readthedocs.io/en/stable/                                                                                                                                                 |
+|                            |     :alt: The uncompromising Python code formatter                                                                                                                                                   |
+|                            | .. image:: https://img.shields.io/badge/%F0%9F%A5%9A-Hatch-4051b5.svg                                                                                                                                |
+|                            |     :target: https://github.com/pypa/hatch                                                                                                                                                           |
+|                            |     :alt: Hatch project                                                                                                                                                                              |
++----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 The SalishSeaCast NEMO command processor, ``salishsea``, is a command line tool
 for doing various operations associated with the `SalishSeaCast NEMO model`_.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -22,51 +22,50 @@
 :kbd:`SalishSeaCmd` Package Development
 ***************************************
 
-+------------------------------+---------------------------------------------------------------------------------------------------------------------+
-|  **Continuous Integration**  |  .. image:: https://github.com/SalishSeaCast/SalishSeaCmd/actions/workflows/pytest-with-coverage.yaml/badge.svg     |
-|                              |       :target: https://github.com/SalishSeaCast/SalishSeaCmd/actions?query=workflow:pytest-with-coverage            |
-|                              |       :alt: Pytest with Coverage Status                                                                             |
-|                              |  .. image:: https://codecov.io/gh/SalishSeaCast/SalishSeaCmd/branch/main/graph/badge.svg                            |
-|                              |       :target: https://app.codecov.io/gh/SalishSeaCast/SalishSeaCmd                                                 |
-|                              |       :alt: Codecov Testing Coverage Report                                                                         |
-|                              |  .. image:: https://github.com/SalishSeaCast/SalishSeaCmd/actions/workflows/codeql-analysis.yaml/badge.svg          |
-|                              |      :target: https://github.com/SalishSeaCast/SalishSeaCmd/actions?query=workflow:CodeQL                           |
-|                              |      :alt: CodeQL analysis                                                                                          |
-+------------------------------+---------------------------------------------------------------------------------------------------------------------+
-|  **Documentation**           |  .. image:: https://readthedocs.org/projects/salishseacmd/badge/?version=latest                                     |
-|                              |      :target: https://salishseacmd.readthedocs.io/en/latest/                                                        |
-|                              |      :alt: Documentation Status                                                                                     |
-|                              |  .. image:: https://github.com/SalishSeaCast/SalishSeaCmd/actions/workflows/sphinx-linkcheck.yaml/badge.svg         |
-|                              |      :target: https://github.com/SalishSeaCast/SalishSeaCmd/actions?query=workflow:sphinx-linkcheck                 |
-|                              |      :alt: Sphinx linkcheck                                                                                         |
-+------------------------------+---------------------------------------------------------------------------------------------------------------------+
-|  **Package**                 |  .. image:: https://img.shields.io/github/v/release/SalishSeaCast/SalishSeaCmd?logo=github                          |
-|                              |      :target: https://github.com/SalishSeaCast/SalishSeaCmd/releases                                                |
-|                              |      :alt: Releases                                                                                                 |
-|                              |  .. image:: https://img.shields.io/badge/Python-3.11%20%7C%203.12-blue?logo=python&label=Python&logoColor=gold      |
-|                              |      :target: https://docs.python.org/3.12/                                                                         |
-|                              |      :alt: Python Version                                                                                           |
-|                              |  .. image:: https://img.shields.io/github/issues/SalishSeaCast/SalishSeaCmd?logo=github                             |
-|                              |      :target: https://github.com/SalishSeaCast/SalishSeaCmd/issues                                                  |
-|                              |      :alt: Issue Tracker                                                                                            |
-+------------------------------+---------------------------------------------------------------------------------------------------------------------+
-|  **Meta**                    |  .. image:: https://img.shields.io/badge/license-Apache%202-cb2533.svg                                              |
-|                              |      :target: https://www.apache.org/licenses/LICENSE-2.0                                                           |
-|                              |      :alt: Licensed under the Apache License, Version 2.0                                                           |
-|                              |  .. image:: https://img.shields.io/badge/version%20control-git-blue.svg?logo=github                                 |
-|                              |      :target: https://github.com/SalishSeaCast/SalishSeaCmd                                                         |
-|                              |      :alt: Git on GitHub                                                                                            |
-|                              |  .. image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white            |
-|                              |      :target: https://pre-commit.com                                                                                |
-|                              |      :alt: pre-commit                                                                                               |
-+                              +---------------------------------------------------------------------------------------------------------------------+
-|                              |  .. image:: https://img.shields.io/badge/code%20style-black-000000.svg                                              |
-|                              |      :target: https://black.readthedocs.io/en/stable/                                                               |
-|                              |      :alt: The uncompromising Python code formatter                                                                 |
-|                              |  .. image:: https://img.shields.io/badge/%F0%9F%A5%9A-Hatch-4051b5.svg                                              |
-|                              |      :target: https://github.com/pypa/hatch                                                                         |
-|                              |      :alt: Hatch project                                                                                            |
-+------------------------------+---------------------------------------------------------------------------------------------------------------------+
++----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| **Continuous Integration** | .. image:: https://github.com/SalishSeaCast/SalishSeaCmd/actions/workflows/pytest-with-coverage.yaml/badge.svg                                                                                       |
+|                            |      :target: https://github.com/SalishSeaCast/SalishSeaCmd/actions?query=workflow:pytest-with-coverage                                                                                              |
+|                            |      :alt: Pytest with Coverage Status                                                                                                                                                               |
+|                            | .. image:: https://codecov.io/gh/SalishSeaCast/SalishSeaCmd/branch/main/graph/badge.svg                                                                                                              |
+|                            |      :target: https://app.codecov.io/gh/SalishSeaCast/SalishSeaCmd                                                                                                                                   |
+|                            |      :alt: Codecov Testing Coverage Report                                                                                                                                                           |
+|                            | .. image:: https://github.com/SalishSeaCast/SalishSeaCmd/actions/workflows/codeql-analysis.yaml/badge.svg                                                                                            |
+|                            |     :target: https://github.com/SalishSeaCast/SalishSeaCmd/actions?query=workflow:CodeQL                                                                                                             |
+|                            |     :alt: CodeQL analysis                                                                                                                                                                            |
++----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| **Documentation**          | .. image:: https://readthedocs.org/projects/salishseacmd/badge/?version=latest                                                                                                                       |
+|                            |     :target: https://salishseacmd.readthedocs.io/en/latest/                                                                                                                                          |
+|                            |     :alt: Documentation Status                                                                                                                                                                       |
+|                            | .. image:: https://github.com/SalishSeaCast/SalishSeaCmd/actions/workflows/sphinx-linkcheck.yaml/badge.svg                                                                                           |
+|                            |     :target: https://github.com/SalishSeaCast/SalishSeaCmd/actions?query=workflow:sphinx-linkcheck                                                                                                   |
+|                            |     :alt: Sphinx linkcheck                                                                                                                                                                           |
++----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| **Package**                | .. image:: https://img.shields.io/github/v/release/SalishSeaCast/SalishSeaCmd?logo=github                                                                                                            |
+|                            |     :target: https://github.com/SalishSeaCast/SalishSeaCmd/releases                                                                                                                                  |
+|                            |     :alt: Releases                                                                                                                                                                                   |
+|                            | .. image:: https://img.shields.io/python/required-version-toml?tomlFilePath=https://raw.githubusercontent.com/SalishSeaCast/SalishSeaCmd/main/pyproject.toml&logo=Python&logoColor=gold&label=Python |
+|                            |      :target: https://docs.python.org/3.12/                                                                                                                                                          |
+|                            |      :alt: Python Version from PEP 621 TOML                                                                                                                                                          |
+|                            | .. image:: https://img.shields.io/github/issues/SalishSeaCast/SalishSeaCmd?logo=github                                                                                                               |
+|                            |     :target: https://github.com/SalishSeaCast/SalishSeaCmd/issues                                                                                                                                    |
+|                            |     :alt: Issue Tracker                                                                                                                                                                              |
++----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| **Meta**                   | .. image:: https://img.shields.io/badge/license-Apache%202-cb2533.svg                                                                                                                                |
+|                            |     :target: https://www.apache.org/licenses/LICENSE-2.0                                                                                                                                             |
+|                            |     :alt: Licensed under the Apache License, Version 2.0                                                                                                                                             |
+|                            | .. image:: https://img.shields.io/badge/version%20control-git-blue.svg?logo=github                                                                                                                   |
+|                            |     :target: https://github.com/SalishSeaCast/SalishSeaCmd                                                                                                                                           |
+|                            |     :alt: Git on GitHub                                                                                                                                                                              |
+|                            | .. image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white                                                                                              |
+|                            |     :target: https://pre-commit.com                                                                                                                                                                  |
+|                            |     :alt: pre-commit                                                                                                                                                                                 |
+|                            | .. image:: https://img.shields.io/badge/code%20style-black-000000.svg                                                                                                                                |
+|                            |     :target: https://black.readthedocs.io/en/stable/                                                                                                                                                 |
+|                            |     :alt: The uncompromising Python code formatter                                                                                                                                                   |
+|                            | .. image:: https://img.shields.io/badge/%F0%9F%A5%9A-Hatch-4051b5.svg                                                                                                                                |
+|                            |     :target: https://github.com/pypa/hatch                                                                                                                                                           |
+|                            |     :alt: Hatch project                                                                                                                                                                              |
++----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 
 .. _SalishSeaCmdPythonVersions:
@@ -74,9 +73,9 @@
 Python Versions
 ===============
 
-.. image:: https://img.shields.io/badge/Python-3.11%20%7C%203.12-blue?logo=python&label=Python&logoColor=gold
+.. image:: https://img.shields.io/python/required-version-toml?tomlFilePath=https://raw.githubusercontent.com/SalishSeaCast/SalishSeaCmd/main/pyproject.toml&logo=Python&logoColor=gold&label=Python
     :target: https://docs.python.org/3.12/
-    :alt: Python Version
+    :alt: Python Version from PEP 621 TOML
 
 The :kbd:`SalishSeaCmd` package is developed using `Python`_ 3.12.
 The minimum supported Python version is 3.11.


### PR DESCRIPTION
This change was necessitated by changes in the GitHub reStructuredText renderer that caused the tables to fail to render on github.com:
* removed split in Meta cell
* reduced spaces between cell separator and text to prevent addition of quoted text bars; it seems that GitHub is doing a reStructuredText to Markdown transformation in the rendering pipeline

Also updated the Python version badge to pull from `pyproject.toml` file so that there is one less change necessary when the Python version is changed.