### PR TITLE
Redirect combine, deflate, & gather output to stdout

### DIFF
--- a/salishsea_cmd/run.py
+++ b/salishsea_cmd/run.py
@@ -1143,7 +1143,7 @@ def _execute(
         )
     script += textwrap.dedent(
         f"""\
-        ${{COMBINE}} ${{RUN_DESC}} --debug
+        ${{COMBINE}} ${{RUN_DESC}} --debug{redirect}
         echo "Results combining ended at $(date)"{redirect}
         """
     )
@@ -1167,7 +1167,7 @@ def _execute(
             f"""\
             ${{DEFLATE}} *_ptrc_T*.nc *_prod_T*.nc *_carp_T*.nc *_grid_[TUVW]*.nc \\
               *_turb_T*.nc *_dia[12n]_T*.nc FVCOM*.nc Slab_[UV]*.nc *_mtrc_T*.nc \\
-              --jobs {max_deflate_jobs} --debug
+              --jobs {max_deflate_jobs} --debug{redirect}
             echo "Results deflation ended at $(date)"{redirect}
             """
         )
@@ -1175,7 +1175,7 @@ def _execute(
         f"""\
 
         echo "Results gathering started at $(date)"{redirect}
-        ${{GATHER}} ${{RESULTS_DIR}} --debug
+        ${{GATHER}} ${{RESULTS_DIR}} --debug{redirect}
         echo "Results gathering ended at $(date)"{redirect}
         """
     )

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -3361,7 +3361,7 @@ class TestExecute:
             echo "Ended run at $(date)" >>${{RESULTS_DIR}}/stdout
 
             echo "Results combining started at $(date)" >>${{RESULTS_DIR}}/stdout
-            ${{COMBINE}} ${{RUN_DESC}} --debug
+            ${{COMBINE}} ${{RUN_DESC}} --debug >>${{RESULTS_DIR}}/stdout
             echo "Results combining ended at $(date)" >>${{RESULTS_DIR}}/stdout
 
             echo "Results deflation started at $(date)" >>${{RESULTS_DIR}}/stdout
@@ -3371,7 +3371,7 @@ class TestExecute:
             echo "Results deflation ended at $(date)" >>${{RESULTS_DIR}}/stdout
 
             echo "Results gathering started at $(date)" >>${{RESULTS_DIR}}/stdout
-            ${{GATHER}} ${{RESULTS_DIR}} --debug
+            ${{GATHER}} ${{RESULTS_DIR}} --debug >>${{RESULTS_DIR}}/stdout
             echo "Results gathering ended at $(date)" >>${{RESULTS_DIR}}/stdout
             """
         )

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -2584,7 +2584,7 @@ class TestBuildBatchScript:
             echo "Ended run at $(date)" >>${RESULTS_DIR}/stdout
 
             echo "Results combining started at $(date)" >>${RESULTS_DIR}/stdout
-            ${COMBINE} ${RUN_DESC} --debug
+            ${COMBINE} ${RUN_DESC} --debug >>${RESULTS_DIR}/stdout
             echo "Results combining ended at $(date)" >>${RESULTS_DIR}/stdout
             """
         )
@@ -2595,7 +2595,7 @@ class TestBuildBatchScript:
                 echo "Results deflation started at $(date)" >>${RESULTS_DIR}/stdout
                 ${DEFLATE} *_ptrc_T*.nc *_prod_T*.nc *_carp_T*.nc *_grid_[TUVW]*.nc \\
                   *_turb_T*.nc *_dia[12n]_T*.nc FVCOM*.nc Slab_[UV]*.nc *_mtrc_T*.nc \\
-                  --jobs 4 --debug
+                  --jobs 4 --debug >>${RESULTS_DIR}/stdout
                 echo "Results deflation ended at $(date)" >>${RESULTS_DIR}/stdout
                 """
             )
@@ -2603,7 +2603,7 @@ class TestBuildBatchScript:
             """\
 
             echo "Results gathering started at $(date)" >>${RESULTS_DIR}/stdout
-            ${GATHER} ${RESULTS_DIR} --debug
+            ${GATHER} ${RESULTS_DIR} --debug >>${RESULTS_DIR}/stdout
             echo "Results gathering ended at $(date)" >>${RESULTS_DIR}/stdout
 
             chmod go+rx ${RESULTS_DIR}
@@ -3367,7 +3367,7 @@ class TestExecute:
             echo "Results deflation started at $(date)" >>${{RESULTS_DIR}}/stdout
             ${{DEFLATE}} *_ptrc_T*.nc *_prod_T*.nc *_carp_T*.nc *_grid_[TUVW]*.nc \\
               *_turb_T*.nc *_dia[12n]_T*.nc FVCOM*.nc Slab_[UV]*.nc *_mtrc_T*.nc \\
-              --jobs 4 --debug
+              --jobs 4 --debug >>${{RESULTS_DIR}}/stdout
             echo "Results deflation ended at $(date)" >>${{RESULTS_DIR}}/stdout
 
             echo "Results gathering started at $(date)" >>${{RESULTS_DIR}}/stdout
@@ -3606,11 +3606,11 @@ class TestExecute:
             echo "Ended run at $(date)" >>${{RESULTS_DIR}}/stdout
 
             echo "Results combining started at $(date)" >>${{RESULTS_DIR}}/stdout
-            ${{COMBINE}} ${{RUN_DESC}} --debug
+            ${{COMBINE}} ${{RUN_DESC}} --debug >>${{RESULTS_DIR}}/stdout
             echo "Results combining ended at $(date)" >>${{RESULTS_DIR}}/stdout
 
             echo "Results gathering started at $(date)" >>${{RESULTS_DIR}}/stdout
-            ${{GATHER}} ${{RESULTS_DIR}} --debug
+            ${{GATHER}} ${{RESULTS_DIR}} --debug >>${{RESULTS_DIR}}/stdout
             echo "Results gathering ended at $(date)" >>${{RESULTS_DIR}}/stdout
             """
         )


### PR DESCRIPTION
Updated the `run.py` script and related tests to ensure that the output of the combine, deflate, and gather commands in run scripts for `salish` is redirected to `${RESULTS_DIR}/stdout`. This was overlooked in PR #80.