### PR TITLE
Exclude version string from coverage

### DIFF
--- a/salishsea_cmd/__about__.py
+++ b/salishsea_cmd/__about__.py
@@ -16,4 +16,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-__version__ = "24.2.dev0"
+__version__ = "24.2.dev0"  # pragma: no cover


### PR DESCRIPTION
Added a pragma directive to the version string to exclude it from test coverage metrics. This ensures that changes to the version number do not affect code coverage reports.