### PR TITLE
Update module version & add dependency for sockeye

### DIFF
--- a/salishsea_cmd/run.py
+++ b/salishsea_cmd/run.py
@@ -1057,9 +1057,10 @@ def _modules():
         ),
         "sockeye": textwrap.dedent(
             """\
-            module load gcc/5.5.0
+            module load gcc/9.4.0
             module load openmpi/4.1.1-cuda11-3
             module load netcdf-fortran/4.5.3-hdf4-support
+            module load parallel-netcdf/1.12.2-additional-bindings
             """
         ),
     }.get(SYSTEM, "")

--- a/salishsea_cmd/run.py
+++ b/salishsea_cmd/run.py
@@ -1122,8 +1122,8 @@ def _execute(
         "seawolf2": f"{mpirun} -np {nemo_processors} ./nemo.exe",
         "seawolf3": f"{mpirun} -np {nemo_processors} ./nemo.exe",
         "sigma": f"{mpirun} --bind-to core -np {nemo_processors} ./nemo.exe",
-        "login01": f"{mpirun} --bind-to core -np {nemo_processors} ./nemo.exe",  # sockeye
-        "login02": f"{mpirun} --bind-to core -np {nemo_processors} ./nemo.exe",  # sockeye
+        "login01": f"{mpirun} -np {nemo_processors} ./nemo.exe",  # sockeye
+        "login02": f"{mpirun} -np {nemo_processors} ./nemo.exe",  # sockeye
     }.get(SYSTEM, f"{mpirun} -np {nemo_processors} ./nemo.exe")
     if xios_processors:
         mpirun = {
@@ -1139,8 +1139,8 @@ def _execute(
             "seawolf2": f"{mpirun} : -np {xios_processors} ./xios_server.exe{redirect}",
             "seawolf3": f"{mpirun} : -np {xios_processors} ./xios_server.exe{redirect}",
             "sigma": f"{mpirun} : --bind-to core -np {xios_processors} ./xios_server.exe{redirect}",
-            "login01": f"{mpirun} : --bind-to core -np {xios_processors} ./xios_server.exe{redirect}",  # sockeye
-            "login02": f"{mpirun} : --bind-to core -np {xios_processors} ./xios_server.exe{redirect}",  # sockeye
+            "login01": f"{mpirun} : -np {xios_processors} ./xios_server.exe{redirect}",  # sockeye
+            "login02": f"{mpirun} : -np {xios_processors} ./xios_server.exe{redirect}",  # sockeye
         }.get(
             SYSTEM,
             f"{mpirun} : -np {xios_processors} ./xios_server.exe{redirect}",

--- a/salishsea_cmd/run.py
+++ b/salishsea_cmd/run.py
@@ -281,7 +281,8 @@ def run(
         "seawolf2": "qsub",  # orcinus.westgrid.ca login node
         "seawolf3": "qsub",  # orcinus.westgrid.ca login node
         "sigma": "qsub -q mpi",  # optimum.eoas.ubc.ca login node
-        "sockeye": "sbatch",
+        "login01": "sbatch",  # sockeye
+        "login02": "sbatch",  # sockeye
     }.get(SYSTEM, "qsub")
     results_dir = nemo_cmd.resolved_path(results_dir)
     run_segments, first_seg_no = _calc_run_segments(desc_file, results_dir)
@@ -649,13 +650,14 @@ def _build_batch_script(
     if SYSTEM == "salish":
         # salish doesn't use a scheduler, so no sbatch or PBS directives in its script
         pass
-    elif SYSTEM in {"beluga", "cedar", "graham", "narval", "sockeye"}:
+    elif SYSTEM in {"beluga", "cedar", "graham", "narval", "login01", "login02"}:
         procs_per_node = {
             "beluga": 40 if not cores_per_node else int(cores_per_node),
             "cedar": 48 if not cores_per_node else int(cores_per_node),
             "graham": 32 if not cores_per_node else int(cores_per_node),
             "narval": 64 if not cores_per_node else int(cores_per_node),
-            "sockeye": 40 if not cores_per_node else int(cores_per_node),
+            "login01": 40 if not cores_per_node else int(cores_per_node),  # sockeye
+            "login02": 40 if not cores_per_node else int(cores_per_node),  # sockeye
         }[SYSTEM]
         script = "\n".join(
             (
@@ -756,7 +758,8 @@ def _sbatch_directives(
         "cedar": "0",
         "graham": "0",
         "narval": "0",
-        "sockeye": "186gb",
+        "login01": "186gb",  # sockeye
+        "login02": "186gb",  # sockeye
     }.get(SYSTEM, mem)
     if deflate:
         run_id = f"{result_type}_{run_id}_deflate"
@@ -768,7 +771,7 @@ def _sbatch_directives(
         ).time()
         td = datetime.timedelta(hours=t.hour, minutes=t.minute, seconds=t.second)
     walltime = _td2hms(td)
-    if SYSTEM in {"cedar", "sockeye"} and cpu_arch:
+    if SYSTEM in {"cedar", "login01", "login02"} and cpu_arch:
         sbatch_directives = (
             f"#SBATCH --job-name={run_id}\n" f"#SBATCH --constraint={cpu_arch}\n"
         )
@@ -788,7 +791,8 @@ def _sbatch_directives(
     except KeyError:
         accounts = {
             "graham": "rrg-allen",
-            "sockeye": "st-sallen1-1",
+            "login01": "st-sallen1-1",  # sockeye
+            "login02": "st-sallen1-1",  # sockeye
         }
         try:
             account = accounts[SYSTEM]
@@ -954,7 +958,8 @@ def _definitions(run_desc, run_desc_file, run_dir, results_dir, deflate):
         "seawolf1": Path("${PBS_O_HOME}", ".local", "bin", "salishsea"),
         "seawolf2": Path("${PBS_O_HOME}", ".local", "bin", "salishsea"),
         "seawolf3": Path("${PBS_O_HOME}", ".local", "bin", "salishsea"),
-        "sockeye": Path("${HOME}", ".local", "bin", "salishsea"),
+        "login01": Path("${HOME}", ".local", "bin", "salishsea"),  # sockeye
+        "login02": Path("${HOME}", ".local", "bin", "salishsea"),  # sockeye
     }.get(SYSTEM, Path("${HOME}", ".local", "bin", "salishsea"))
     defns = (
         f'RUN_ID="{get_run_desc_value(run_desc, ("run_id",))}"\n'
@@ -1055,7 +1060,15 @@ def _modules():
             module load OpenMPI/2.1.6/GCC/SYSTEM
             """
         ),
-        "sockeye": textwrap.dedent(
+        "login01": textwrap.dedent(  # sockeye
+            """\
+            module load gcc/9.4.0
+            module load openmpi/4.1.1-cuda11-3
+            module load netcdf-fortran/4.5.3-hdf4-support
+            module load parallel-netcdf/1.12.2-additional-bindings
+            """
+        ),
+        "login02": textwrap.dedent(  # sockeye
             """\
             module load gcc/9.4.0
             module load openmpi/4.1.1-cuda11-3
@@ -1093,7 +1106,8 @@ def _execute(
         "seawolf2": "mpirun",
         "seawolf3": "mpirun",
         "sigma": "mpiexec -hostfile $(openmpi_nodefile)",
-        "sockeye": "mpirun",
+        "login01": "mpirun",  # sockeye
+        "login02": "mpirun",  # sockeye
     }.get(SYSTEM, "mpirun")
     mpirun = {
         "beluga": f"{mpirun} -np {nemo_processors} ./nemo.exe",
@@ -1108,7 +1122,8 @@ def _execute(
         "seawolf2": f"{mpirun} -np {nemo_processors} ./nemo.exe",
         "seawolf3": f"{mpirun} -np {nemo_processors} ./nemo.exe",
         "sigma": f"{mpirun} --bind-to core -np {nemo_processors} ./nemo.exe",
-        "sockeye": f"{mpirun} --bind-to core -np {nemo_processors} ./nemo.exe",
+        "login01": f"{mpirun} --bind-to core -np {nemo_processors} ./nemo.exe",  # sockeye
+        "login02": f"{mpirun} --bind-to core -np {nemo_processors} ./nemo.exe",  # sockeye
     }.get(SYSTEM, f"{mpirun} -np {nemo_processors} ./nemo.exe")
     if xios_processors:
         mpirun = {
@@ -1124,7 +1139,8 @@ def _execute(
             "seawolf2": f"{mpirun} : -np {xios_processors} ./xios_server.exe{redirect}",
             "seawolf3": f"{mpirun} : -np {xios_processors} ./xios_server.exe{redirect}",
             "sigma": f"{mpirun} : --bind-to core -np {xios_processors} ./xios_server.exe{redirect}",
-            "sockeye": f"{mpirun} : --bind-to core -np {xios_processors} ./xios_server.exe{redirect}",
+            "login01": f"{mpirun} : --bind-to core -np {xios_processors} ./xios_server.exe{redirect}",  # sockeye
+            "login02": f"{mpirun} : --bind-to core -np {xios_processors} ./xios_server.exe{redirect}",  # sockeye
         }.get(
             SYSTEM,
             f"{mpirun} : -np {xios_processors} ./xios_server.exe{redirect}",

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -2901,7 +2901,7 @@ class TestBuildBatchScript:
             echo "working dir: $(pwd)"
 
             echo "Starting run at $(date)"
-            mpirun --bind-to core -np 42 ./nemo.exe : --bind-to core -np 1 ./xios_server.exe
+            mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe
             MPIRUN_EXIT_CODE=$?
             echo "Ended run at $(date)"
 
@@ -3552,13 +3552,13 @@ class TestExecute:
                 "mpiexec -hostfile $(openmpi_nodefile) --bind-to core -np 42 ./nemo.exe : --bind-to core -np 1 ./xios_server.exe",
             ),
             (
-                "login01",  # sockeye
-                "mpirun --bind-to core -np 42 ./nemo.exe : --bind-to core -np 1 ./xios_server.exe",
-            ),
+                "login01",
+                "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe",
+            ),  # sockeye
             (
-                "login02",  # sockeye
-                "mpirun --bind-to core -np 42 ./nemo.exe : --bind-to core -np 1 ./xios_server.exe",
-            ),
+                "login02",
+                "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe",
+            ),  # sockeye
         ],
     )
     def test_execute_with_deflate(self, system, mpirun_cmd, monkeypatch):
@@ -3802,37 +3802,37 @@ class TestExecute:
             ),
             (
                 "login01",  # sockeye
-                "mpirun --bind-to core -np 42 ./nemo.exe : --bind-to core -np 1 ./xios_server.exe",
+                "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe",
                 False,
                 True,
             ),
             (
                 "login01",  # sockeye
-                "mpirun --bind-to core -np 42 ./nemo.exe : --bind-to core -np 1 ./xios_server.exe",
+                "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe",
                 False,
                 False,
             ),
             (
                 "login01",  # sockeye
-                "mpirun --bind-to core -np 42 ./nemo.exe : --bind-to core -np 1 ./xios_server.exe",
+                "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe",
                 True,
                 True,
             ),
             (
                 "login02",  # sockeye
-                "mpirun --bind-to core -np 42 ./nemo.exe : --bind-to core -np 1 ./xios_server.exe",
+                "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe",
                 False,
                 True,
             ),
             (
                 "login02",  # sockeye
-                "mpirun --bind-to core -np 42 ./nemo.exe : --bind-to core -np 1 ./xios_server.exe",
+                "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe",
                 False,
                 False,
             ),
             (
                 "login02",  # sockeye
-                "mpirun --bind-to core -np 42 ./nemo.exe : --bind-to core -np 1 ./xios_server.exe",
+                "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe",
                 True,
                 True,
             ),

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -2857,9 +2857,10 @@ class TestBuildBatchScript:
             """\
             GATHER="${HOME}/.local/bin/salishsea gather"
 
-            module load gcc/5.5.0
+            module load gcc/9.4.0
             module load openmpi/4.1.1-cuda11-3
             module load netcdf-fortran/4.5.3-hdf4-support
+            module load parallel-netcdf/1.12.2-additional-bindings
 
             mkdir -p ${RESULTS_DIR}
             cd ${WORK_DIR}
@@ -3482,9 +3483,10 @@ class TestModules:
 
         expected = textwrap.dedent(
             """\
-            module load gcc/5.5.0
+            module load gcc/9.4.0
             module load openmpi/4.1.1-cuda11-3
             module load netcdf-fortran/4.5.3-hdf4-support
+            module load parallel-netcdf/1.12.2-additional-bindings
             """
         )
         assert modules == expected

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -149,8 +149,10 @@ class TestRun:
             (True, 4, "salish", "bash", "bash run_dir/SalishSeaNEMO.sh started"),
             (False, 0, "sigma", "qsub -q mpi", "43.admin.default.domain"),
             (True, 4, "sigma", "qsub -q mpi", "43.admin.default.domain"),
-            (False, 0, "sockeye", "sbatch", "Submitted batch job 43"),
-            (True, 4, "sockeye", "sbatch", "Submitted batch job 43"),
+            (False, 0, "login01", "sbatch", "Submitted batch job 43"),  # sockeye
+            (True, 4, "login01", "sbatch", "Submitted batch job 43"),  # sockeye
+            (False, 0, "login02", "sbatch", "Submitted batch job 43"),  # sockeye
+            (True, 4, "login02", "sbatch", "Submitted batch job 43"),  # sockeye
             (False, 0, "omega", "qsub -q mpi", "43.admin.default.domain"),
             (True, 4, "omega", "qsub -q mpi", "43.admin.default.domain"),
             (False, 0, "orcinus", "qsub", "43.orca2.ibb"),
@@ -231,8 +233,10 @@ class TestRun:
             (True, 4, "salish", "bash", "bash run_dir/SalishSeaNEMO.sh started"),
             (False, 0, "sigma", "qsub -q mpi", "43.admin.default.domain"),
             (True, 4, "sigma", "qsub -q mpi", "43.admin.default.domain"),
-            (False, 0, "sockeye", "sbatch", "Submitted batch job 43"),
-            (True, 4, "sockeye", "sbatch", "Submitted batch job 43"),
+            (False, 0, "login01", "sbatch", "Submitted batch job 43"),  # sockeye
+            (True, 4, "login01", "sbatch", "Submitted batch job 43"),  # sockeye
+            (False, 0, "login02", "sbatch", "Submitted batch job 43"),  # sockeye
+            (True, 4, "login02", "sbatch", "Submitted batch job 43"),  # sockeye
             (False, 0, "omega", "qsub -q mpi", "43.admin.default.domain"),
             (True, 4, "omega", "qsub -q mpi", "43.admin.default.domain"),
             (False, 0, "orcinus", "qsub", "43.orca2.ibb"),
@@ -408,8 +412,10 @@ class TestRun:
             (True, 4, "salish", "bash", "bash run_dir/SalishSeaNEMO.sh started"),
             (False, 0, "sigma", "qsub -q mpi", "43.admin.default.domain"),
             (True, 4, "sigma", "qsub -q mpi", "43.admin.default.domain"),
-            (False, 0, "sockeye", "sbatch", "Submitted batch job 43"),
-            (True, 4, "sockeye", "sbatch", "Submitted batch job 43"),
+            (False, 0, "login01", "sbatch", "Submitted batch job 43"),  # sockeye
+            (True, 4, "login01", "sbatch", "Submitted batch job 43"),  # sockeye
+            (False, 0, "login02", "sbatch", "Submitted batch job 43"),  # sockeye
+            (True, 4, "login02", "sbatch", "Submitted batch job 43"),  # sockeye
             (False, 0, "omega", "qsub -q mpi", "43.admin.default.domain"),
             (True, 4, "omega", "qsub -q mpi", "43.admin.default.domain"),
             (False, 0, "orcinus", "qsub", "43.orca2.ibb"),
@@ -818,9 +824,33 @@ class TestRun:
                 "43.admin.default.domain",
             ),
             (
+                False,
+                0,
+                "login01",  # sockeye
+                "sbatch",
+                ("Submitted batch job 43", "Submitted batch job 44"),
+                "Submitted batch job 43",
+            ),
+            (
                 True,
                 4,
-                "sockeye",
+                "login01",  # sockeye
+                "sbatch",
+                ("Submitted batch job 43", "Submitted batch job 44"),
+                "Submitted batch job 43",
+            ),
+            (
+                False,
+                0,
+                "login02",  # sockeye
+                "sbatch",
+                ("Submitted batch job 43", "Submitted batch job 44"),
+                "Submitted batch job 43",
+            ),
+            (
+                True,
+                4,
+                "login02",  # sockeye
                 "sbatch",
                 ("Submitted batch job 43", "Submitted batch job 44"),
                 "Submitted batch job 43",
@@ -2783,20 +2813,24 @@ class TestBuildBatchScript:
         assert script == expected
 
     @pytest.mark.parametrize(
-        "cores_per_node, cpu_arch, deflate",
+        "node_name, cores_per_node, cpu_arch, deflate",
         [
-            ("", "", True),
-            ("", "", False),
-            ("32", "skylake", False),
-            ("40", "cascade", False),
+            ("login01", "", "", True),
+            ("login01", "", "", False),
+            ("login01", "32", "skylake", False),
+            ("login01", "40", "cascade", False),
+            ("login02", "", "", True),
+            ("login02", "", "", False),
+            ("login02", "32", "skylake", False),
+            ("login02", "40", "cascade", False),
         ],
     )
-    def test_sockeye(self, cores_per_node, cpu_arch, deflate, monkeypatch):
+    def test_sockeye(self, node_name, cores_per_node, cpu_arch, deflate, monkeypatch):
         desc_file = StringIO(
             "run_id: foo\n" "walltime: 01:02:03\n" "email: me@example.com"
         )
         run_desc = yaml.safe_load(desc_file)
-        monkeypatch.setattr(salishsea_cmd.run, "SYSTEM", "sockeye")
+        monkeypatch.setattr(salishsea_cmd.run, "SYSTEM", node_name)
 
         script = salishsea_cmd.run._build_batch_script(
             run_desc,
@@ -3095,10 +3129,11 @@ class TestSbatchDirectives:
         )
         assert slurm_directives == expected
 
-    def test_sockeye_sbatch_directives(self, caplog, monkeypatch):
+    @pytest.mark.parametrize("node_name", ["login01", "login02"])
+    def test_sockeye_sbatch_directives(self, node_name, caplog, monkeypatch):
         desc_file = StringIO("run_id: foo\n" "walltime: 01:02:03\n")
         run_desc = yaml.safe_load(desc_file)
-        monkeypatch.setattr(salishsea_cmd.run, "SYSTEM", "sockeye")
+        monkeypatch.setattr(salishsea_cmd.run, "SYSTEM", node_name)
         caplog.set_level(logging.DEBUG)
 
         slurm_directives = salishsea_cmd.run._sbatch_directives(
@@ -3476,8 +3511,9 @@ class TestModules:
         )
         assert modules == expected
 
-    def test_sockeye(self, monkeypatch):
-        monkeypatch.setattr(salishsea_cmd.run, "SYSTEM", "sockeye")
+    @pytest.mark.parametrize("node_name", ["login01", "login02"])
+    def test_sockeye(self, node_name, monkeypatch):
+        monkeypatch.setattr(salishsea_cmd.run, "SYSTEM", node_name)
 
         modules = salishsea_cmd.run._modules()
 
@@ -3516,7 +3552,11 @@ class TestExecute:
                 "mpiexec -hostfile $(openmpi_nodefile) --bind-to core -np 42 ./nemo.exe : --bind-to core -np 1 ./xios_server.exe",
             ),
             (
-                "sockeye",
+                "login01",  # sockeye
+                "mpirun --bind-to core -np 42 ./nemo.exe : --bind-to core -np 1 ./xios_server.exe",
+            ),
+            (
+                "login02",  # sockeye
                 "mpirun --bind-to core -np 42 ./nemo.exe : --bind-to core -np 1 ./xios_server.exe",
             ),
         ],
@@ -3761,19 +3801,37 @@ class TestExecute:
                 True,
             ),
             (
-                "sockeye",
+                "login01",  # sockeye
                 "mpirun --bind-to core -np 42 ./nemo.exe : --bind-to core -np 1 ./xios_server.exe",
                 False,
                 True,
             ),
             (
-                "sockeye",
+                "login01",  # sockeye
                 "mpirun --bind-to core -np 42 ./nemo.exe : --bind-to core -np 1 ./xios_server.exe",
                 False,
                 False,
             ),
             (
-                "sockeye",
+                "login01",  # sockeye
+                "mpirun --bind-to core -np 42 ./nemo.exe : --bind-to core -np 1 ./xios_server.exe",
+                True,
+                True,
+            ),
+            (
+                "login02",  # sockeye
+                "mpirun --bind-to core -np 42 ./nemo.exe : --bind-to core -np 1 ./xios_server.exe",
+                False,
+                True,
+            ),
+            (
+                "login02",  # sockeye
+                "mpirun --bind-to core -np 42 ./nemo.exe : --bind-to core -np 1 ./xios_server.exe",
+                False,
+                False,
+            ),
+            (
+                "login02",  # sockeye
                 "mpirun --bind-to core -np 42 ./nemo.exe : --bind-to core -np 1 ./xios_server.exe",
                 True,
                 True,


### PR DESCRIPTION
Upgraded GCC to version 9.4.0 for compatibility with the present sockeye software environment and added the `parallel-netcdf/1.12.2-additional-bindings` module. Updated corresponding test cases to reflect these changes, ensuring alignment with the new module configurations.