### PR TITLE
Add support for `fir` HPC system

### DIFF
--- a/salishsea_cmd/run.py
+++ b/salishsea_cmd/run.py
@@ -268,6 +268,7 @@ def run(
     """
     queue_job_cmd = {
         # Alliance Canada clusters
+        "fir": "sbatch",
         "narval": "sbatch",
         "nibi": "sbatch",
         # UBC ARC sockeye cluster
@@ -653,6 +654,7 @@ def _build_batch_script(
         pass
     elif SYSTEM in {
         # Alliance Canada clusters
+        "fir",
         "narval",
         "nibi",
         # UBC ARC sockeye cluster
@@ -661,6 +663,7 @@ def _build_batch_script(
     }:
         procs_per_node = {
             # Alliance Canada clusters
+            "fir": 192 if not cores_per_node else int(cores_per_node),
             "narval": 64 if not cores_per_node else int(cores_per_node),
             "nibi": 192 if not cores_per_node else int(cores_per_node),
             # UBC ARC sockeye cluster
@@ -765,6 +768,7 @@ def _sbatch_directives(
     nodes = math.ceil(n_processors / procs_per_node)
     mem = {
         # Alliance Canada clusters
+        "fir": "0",
         "narval": "0",
         "nibi": "0",
         # UBC ARC sockeye cluster
@@ -959,6 +963,7 @@ def _td2hms(timedelta):
 def _definitions(run_desc, run_desc_file, run_dir, results_dir, deflate):
     salishsea_cmd = {
         # Alliance Canada clusters
+        "fir": Path("${HOME}", ".local", "bin", "salishsea"),
         "narval": Path("${HOME}", ".local", "bin", "salishsea"),
         "nibi": Path("${HOME}", ".local", "bin", "salishsea"),
         # UBC ARC sockeye cluster
@@ -992,6 +997,12 @@ def _definitions(run_desc, run_desc_file, run_dir, results_dir, deflate):
 def _modules():
     modules = {
         # Alliance Canada clusters
+        "fir": textwrap.dedent(
+            """\
+            module load StdEnv/2023
+            module load netcdf-fortran-mpi/4.6.1
+            """
+        ),
         "narval": textwrap.dedent(
             """\
             module load StdEnv/2020
@@ -1103,6 +1114,7 @@ def _execute(
     )
     mpirun = {
         # Alliance Canada clusters
+        "fir": "mpirun",
         "narval": "mpirun",
         "nibi": "mpirun",
         # UBC ARC sockeye cluster
@@ -1122,6 +1134,7 @@ def _execute(
     }.get(SYSTEM, "mpirun")
     mpirun = {
         # Alliance Canada clusters
+        "fir": f"{mpirun} -np {nemo_processors} ./nemo.exe",
         "narval": f"{mpirun} -np {nemo_processors} ./nemo.exe",
         "nibi": f"{mpirun} -np {nemo_processors} ./nemo.exe",
         # UBC ARC sockeye cluster
@@ -1142,6 +1155,7 @@ def _execute(
     if xios_processors:
         mpirun = {
             # Alliance Canada clusters
+            "fir": f"{mpirun} : -np {xios_processors} ./xios_server.exe{redirect}",
             "narval": f"{mpirun} : -np {xios_processors} ./xios_server.exe{redirect}",
             "nibi": f"{mpirun} : -np {xios_processors} ./xios_server.exe{redirect}",
             # UBC ARC sockeye cluster
@@ -1204,7 +1218,7 @@ def _execute(
             echo "Results deflation started at $(date)"{redirect}
             """
         )
-        if SYSTEM in {"narval", "nibi"}:
+        if SYSTEM in {"fir", "narval", "nibi"}:
             # Load the nco module just before deflation because it replaces
             # the netcdf-mpi and netcdf-fortran-mpi modules with their non-mpi
             # variants

--- a/salishsea_cmd/run.py
+++ b/salishsea_cmd/run.py
@@ -267,18 +267,23 @@ def run(
     :rtype: str
     """
     queue_job_cmd = {
-        "delta": "qsub -q mpi",  # optimum.eoas.ubc.ca login node
+        # Alliance Canada clusters
         "narval": "sbatch",
         "nibi": "sbatch",
-        "omega": "qsub -q mpi",  # optimum.eoas.ubc.ca login node
-        "orcinus": "qsub",
+        # UBC ARC sockeye cluster
+        "login01": "sbatch",
+        "login02": "sbatch",
+        # MOAD development machine
         "salish": "bash",
+        # UBC Chemistry orcinus cluster
+        "orcinus": "qsub",
         "seawolf1": "qsub",  # orcinus.westgrid.ca login node
         "seawolf2": "qsub",  # orcinus.westgrid.ca login node
         "seawolf3": "qsub",  # orcinus.westgrid.ca login node
+        # EOAS optimum cluster
+        "delta": "qsub -q mpi",  # optimum.eoas.ubc.ca login node
+        "omega": "qsub -q mpi",  # optimum.eoas.ubc.ca login node
         "sigma": "qsub -q mpi",  # optimum.eoas.ubc.ca login node
-        "login01": "sbatch",  # sockeye
-        "login02": "sbatch",  # sockeye
     }.get(SYSTEM, "qsub")
     results_dir = nemo_cmd.resolved_path(results_dir)
     run_segments, first_seg_no = _calc_run_segments(desc_file, results_dir)
@@ -647,16 +652,20 @@ def _build_batch_script(
         # salish doesn't use a scheduler, so no sbatch or PBS directives in its script
         pass
     elif SYSTEM in {
+        # Alliance Canada clusters
         "narval",
         "nibi",
+        # UBC ARC sockeye cluster
         "login01",
         "login02",
     }:
         procs_per_node = {
+            # Alliance Canada clusters
             "narval": 64 if not cores_per_node else int(cores_per_node),
             "nibi": 192 if not cores_per_node else int(cores_per_node),
-            "login01": 40 if not cores_per_node else int(cores_per_node),  # sockeye
-            "login02": 40 if not cores_per_node else int(cores_per_node),  # sockeye
+            # UBC ARC sockeye cluster
+            "login01": 40 if not cores_per_node else int(cores_per_node),
+            "login02": 40 if not cores_per_node else int(cores_per_node),
         }[SYSTEM]
         script = "\n".join(
             (
@@ -667,13 +676,15 @@ def _build_batch_script(
     else:
         try:
             procs_per_node = {
-                "delta": 20 if not cores_per_node else int(cores_per_node),
-                "omega": 20 if not cores_per_node else int(cores_per_node),
-                "sigma": 20 if not cores_per_node else int(cores_per_node),
+                # UBC Chemistry orcinus cluster
                 "orcinus": 12 if not cores_per_node else int(cores_per_node),
                 "seawolf1": 12 if not cores_per_node else int(cores_per_node),
                 "seawolf2": 12 if not cores_per_node else int(cores_per_node),
                 "seawolf3": 12 if not cores_per_node else int(cores_per_node),
+                # EOAS optimum cluster
+                "delta": 20 if not cores_per_node else int(cores_per_node),
+                "omega": 20 if not cores_per_node else int(cores_per_node),
+                "sigma": 20 if not cores_per_node else int(cores_per_node),
             }[SYSTEM]
         except KeyError:
             log.error(f"unknown system: {SYSTEM}")
@@ -753,10 +764,12 @@ def _sbatch_directives(
     run_id = get_run_desc_value(run_desc, ("run_id",))
     nodes = math.ceil(n_processors / procs_per_node)
     mem = {
+        # Alliance Canada clusters
         "narval": "0",
         "nibi": "0",
-        "login01": "186gb",  # sockeye
-        "login02": "186gb",  # sockeye
+        # UBC ARC sockeye cluster
+        "login01": "186gb",
+        "login02": "186gb",
     }.get(SYSTEM, mem)
     if deflate:
         run_id = f"{result_type}_{run_id}_deflate"
@@ -787,9 +800,11 @@ def _sbatch_directives(
         sbatch_directives += f"#SBATCH --account={account}\n"
     except KeyError:
         accounts = {
-            "login01": "st-sallen1-1",  # sockeye
-            "login02": "st-sallen1-1",  # sockeye
+            # Alliance Canada clusters
             "nibi": "def-allen",  # until allocation is activated, then rrg-allen
+            # UBC ARC sockeye cluster
+            "login01": "st-sallen1-1",
+            "login02": "st-sallen1-1",
         }
         try:
             account = accounts[SYSTEM]
@@ -943,18 +958,23 @@ def _td2hms(timedelta):
 
 def _definitions(run_desc, run_desc_file, run_dir, results_dir, deflate):
     salishsea_cmd = {
-        "delta": Path("${PBS_O_HOME}", "bin", "salishsea"),
+        # Alliance Canada clusters
         "narval": Path("${HOME}", ".local", "bin", "salishsea"),
         "nibi": Path("${HOME}", ".local", "bin", "salishsea"),
-        "omega": Path("${PBS_O_HOME}", "bin", "salishsea"),
-        "orcinus": Path("${PBS_O_HOME}", ".local", "bin", "salishsea"),
-        "sigma": Path("${PBS_O_HOME}", "bin", "salishsea"),
+        # UBC ARC sockeye cluster
+        "login01": Path("${HOME}", ".local", "bin", "salishsea"),
+        "login02": Path("${HOME}", ".local", "bin", "salishsea"),
+        # MOAD development machine
         "salish": Path("${HOME}", ".local", "bin", "salishsea"),
+        # UBC Chemistry orcinus cluster
+        "orcinus": Path("${PBS_O_HOME}", ".local", "bin", "salishsea"),
         "seawolf1": Path("${PBS_O_HOME}", ".local", "bin", "salishsea"),
         "seawolf2": Path("${PBS_O_HOME}", ".local", "bin", "salishsea"),
         "seawolf3": Path("${PBS_O_HOME}", ".local", "bin", "salishsea"),
-        "login01": Path("${HOME}", ".local", "bin", "salishsea"),  # sockeye
-        "login02": Path("${HOME}", ".local", "bin", "salishsea"),  # sockeye
+        # EOAS optimum cluster
+        "delta": Path("${PBS_O_HOME}", "bin", "salishsea"),
+        "omega": Path("${PBS_O_HOME}", "bin", "salishsea"),
+        "sigma": Path("${PBS_O_HOME}", "bin", "salishsea"),
     }.get(SYSTEM, Path("${HOME}", ".local", "bin", "salishsea"))
     defns = (
         f'RUN_ID="{get_run_desc_value(run_desc, ("run_id",))}"\n'
@@ -971,11 +991,7 @@ def _definitions(run_desc, run_desc_file, run_dir, results_dir, deflate):
 
 def _modules():
     modules = {
-        "delta": textwrap.dedent(
-            """\
-            module load OpenMPI/2.1.6/GCC/SYSTEM
-            """
-        ),
+        # Alliance Canada clusters
         "narval": textwrap.dedent(
             """\
             module load StdEnv/2020
@@ -988,11 +1004,26 @@ def _modules():
             module load netcdf-fortran-mpi/4.6.1
             """
         ),
-        "omega": textwrap.dedent(
+        # UBC ARC sockeye cluster
+        "login01": textwrap.dedent(
             """\
-            module load OpenMPI/2.1.6/GCC/SYSTEM
+            module load gcc/9.4.0
+            module load openmpi/4.1.1-cuda11-3
+            module load netcdf-fortran/4.5.3-hdf4-support
+            module load parallel-netcdf/1.12.2-additional-bindings
             """
         ),
+        "login02": textwrap.dedent(
+            """\
+            module load gcc/9.4.0
+            module load openmpi/4.1.1-cuda11-3
+            module load netcdf-fortran/4.5.3-hdf4-support
+            module load parallel-netcdf/1.12.2-additional-bindings
+            """
+        ),
+        # MOAD development machine
+        "salish": "",
+        # UBC Chemistry orcinus cluster
         "orcinus": textwrap.dedent(
             """\
             module load intel
@@ -1004,7 +1035,6 @@ def _modules():
             module load git
             """
         ),
-        "salish": "",
         "seawolf1": textwrap.dedent(
             """\
             module load intel
@@ -1038,25 +1068,20 @@ def _modules():
             module load git
             """
         ),
-        "sigma": textwrap.dedent(
+        # EOAS optimum cluster
+        "delta": textwrap.dedent(
             """\
             module load OpenMPI/2.1.6/GCC/SYSTEM
             """
         ),
-        "login01": textwrap.dedent(  # sockeye
+        "omega": textwrap.dedent(
             """\
-            module load gcc/9.4.0
-            module load openmpi/4.1.1-cuda11-3
-            module load netcdf-fortran/4.5.3-hdf4-support
-            module load parallel-netcdf/1.12.2-additional-bindings
+            module load OpenMPI/2.1.6/GCC/SYSTEM
             """
         ),
-        "login02": textwrap.dedent(  # sockeye
+        "sigma": textwrap.dedent(
             """\
-            module load gcc/9.4.0
-            module load openmpi/4.1.1-cuda11-3
-            module load netcdf-fortran/4.5.3-hdf4-support
-            module load parallel-netcdf/1.12.2-additional-bindings
+            module load OpenMPI/2.1.6/GCC/SYSTEM
             """
         ),
     }.get(SYSTEM, "")
@@ -1077,47 +1102,62 @@ def _execute(
         else " >>${RESULTS_DIR}/stdout 2>>${RESULTS_DIR}/stderr"
     )
     mpirun = {
-        "delta": "mpiexec -hostfile $(openmpi_nodefile)",
+        # Alliance Canada clusters
         "narval": "mpirun",
         "nibi": "mpirun",
-        "omega": "mpiexec -hostfile $(openmpi_nodefile)",
-        "orcinus": "mpirun",
+        # UBC ARC sockeye cluster
+        "login01": "mpirun",
+        "login02": "mpirun",
+        # MOAD development machine
         "salish": "/usr/bin/mpirun",
+        # UBC Chemistry orcinus cluster
+        "orcinus": "mpirun",
         "seawolf1": "mpirun",
         "seawolf2": "mpirun",
         "seawolf3": "mpirun",
+        # EOAS optimum cluster
+        "delta": "mpiexec -hostfile $(openmpi_nodefile)",
+        "omega": "mpiexec -hostfile $(openmpi_nodefile)",
         "sigma": "mpiexec -hostfile $(openmpi_nodefile)",
-        "login01": "mpirun",  # sockeye
-        "login02": "mpirun",  # sockeye
     }.get(SYSTEM, "mpirun")
     mpirun = {
-        "delta": f"{mpirun} --bind-to core -np {nemo_processors} ./nemo.exe",
+        # Alliance Canada clusters
         "narval": f"{mpirun} -np {nemo_processors} ./nemo.exe",
         "nibi": f"{mpirun} -np {nemo_processors} ./nemo.exe",
-        "omega": f"{mpirun} --bind-to core -np {nemo_processors} ./nemo.exe",
-        "orcinus": f"{mpirun} -np {nemo_processors} ./nemo.exe",
+        # UBC ARC sockeye cluster
+        "login01": f"{mpirun} -np {nemo_processors} ./nemo.exe",
+        "login02": f"{mpirun} -np {nemo_processors} ./nemo.exe",
+        # MOAD development machine
         "salish": f"{mpirun} --bind-to none -np {nemo_processors} ./nemo.exe",
+        # UBC Chemistry orcinus cluster
+        "orcinus": f"{mpirun} -np {nemo_processors} ./nemo.exe",
         "seawolf1": f"{mpirun} -np {nemo_processors} ./nemo.exe",
         "seawolf2": f"{mpirun} -np {nemo_processors} ./nemo.exe",
         "seawolf3": f"{mpirun} -np {nemo_processors} ./nemo.exe",
+        # EOAS optimum cluster
+        "delta": f"{mpirun} --bind-to core -np {nemo_processors} ./nemo.exe",
+        "omega": f"{mpirun} --bind-to core -np {nemo_processors} ./nemo.exe",
         "sigma": f"{mpirun} --bind-to core -np {nemo_processors} ./nemo.exe",
-        "login01": f"{mpirun} -np {nemo_processors} ./nemo.exe",  # sockeye
-        "login02": f"{mpirun} -np {nemo_processors} ./nemo.exe",  # sockeye
     }.get(SYSTEM, f"{mpirun} -np {nemo_processors} ./nemo.exe")
     if xios_processors:
         mpirun = {
-            "delta": f"{mpirun} : --bind-to core -np {xios_processors} ./xios_server.exe{redirect}",
+            # Alliance Canada clusters
             "narval": f"{mpirun} : -np {xios_processors} ./xios_server.exe{redirect}",
             "nibi": f"{mpirun} : -np {xios_processors} ./xios_server.exe{redirect}",
-            "omega": f"{mpirun} : --bind-to core -np {xios_processors} ./xios_server.exe{redirect}",
-            "orcinus": f"{mpirun} : -np {xios_processors} ./xios_server.exe{redirect}",
+            # UBC ARC sockeye cluster
+            "login01": f"{mpirun} : -np {xios_processors} ./xios_server.exe{redirect}",
+            "login02": f"{mpirun} : -np {xios_processors} ./xios_server.exe{redirect}",
+            # MOAD development machine
             "salish": f"{mpirun} : --bind-to none -np {xios_processors} ./xios_server.exe{redirect}",
+            # UBC Chemistry orcinus cluster
+            "orcinus": f"{mpirun} : -np {xios_processors} ./xios_server.exe{redirect}",
             "seawolf1": f"{mpirun} : -np {xios_processors} ./xios_server.exe{redirect}",
             "seawolf2": f"{mpirun} : -np {xios_processors} ./xios_server.exe{redirect}",
             "seawolf3": f"{mpirun} : -np {xios_processors} ./xios_server.exe{redirect}",
+            # EOAS optimum cluster
+            "delta": f"{mpirun} : --bind-to core -np {xios_processors} ./xios_server.exe{redirect}",
+            "omega": f"{mpirun} : --bind-to core -np {xios_processors} ./xios_server.exe{redirect}",
             "sigma": f"{mpirun} : --bind-to core -np {xios_processors} ./xios_server.exe{redirect}",
-            "login01": f"{mpirun} : -np {xios_processors} ./xios_server.exe{redirect}",  # sockeye
-            "login02": f"{mpirun} : -np {xios_processors} ./xios_server.exe{redirect}",  # sockeye
         }.get(
             SYSTEM,
             f"{mpirun} : -np {xios_processors} ./xios_server.exe{redirect}",

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -135,22 +135,20 @@ class TestRun:
     @pytest.mark.parametrize(
         "sep_xios_server, xios_servers, system, queue_job_cmd, submit_job_msg",
         [
-            (False, 0, "delta", "qsub -q mpi", "43.admin.default.domain"),
-            (True, 4, "delta", "qsub -q mpi", "43.admin.default.domain"),
+            # Alliance Canada clusters
             (False, 0, "narval", "sbatch", "Submitted batch job 43"),
             (True, 4, "narval", "sbatch", "Submitted batch job 43"),
             (False, 0, "nibi", "sbatch", "Submitted batch job 43"),
             (True, 4, "nibi", "sbatch", "Submitted batch job 43"),
+            # UBC ARC sockeye cluster
+            (False, 0, "login01", "sbatch", "Submitted batch job 43"),
+            (True, 4, "login01", "sbatch", "Submitted batch job 43"),
+            (False, 0, "login02", "sbatch", "Submitted batch job 43"),
+            (True, 4, "login02", "sbatch", "Submitted batch job 43"),
+            # MOAD development machine
             (False, 0, "salish", "bash", "bash run_dir/SalishSeaNEMO.sh started"),
             (True, 4, "salish", "bash", "bash run_dir/SalishSeaNEMO.sh started"),
-            (False, 0, "sigma", "qsub -q mpi", "43.admin.default.domain"),
-            (True, 4, "sigma", "qsub -q mpi", "43.admin.default.domain"),
-            (False, 0, "login01", "sbatch", "Submitted batch job 43"),  # sockeye
-            (True, 4, "login01", "sbatch", "Submitted batch job 43"),  # sockeye
-            (False, 0, "login02", "sbatch", "Submitted batch job 43"),  # sockeye
-            (True, 4, "login02", "sbatch", "Submitted batch job 43"),  # sockeye
-            (False, 0, "omega", "qsub -q mpi", "43.admin.default.domain"),
-            (True, 4, "omega", "qsub -q mpi", "43.admin.default.domain"),
+            # UBC Chemistry orcinus cluster
             (False, 0, "orcinus", "qsub", "43.orca2.ibb"),
             (True, 4, "orcinus", "qsub", "43.orca2.ibb"),
             (False, 0, "seawolf1", "qsub", "431.orca2.ibb"),
@@ -159,6 +157,13 @@ class TestRun:
             (True, 4, "seawolf2", "qsub", "432.orca2.ibb"),
             (False, 0, "seawolf3", "qsub", "433.orca2.ibb"),
             (True, 4, "seawolf3", "qsub", "433.orca2.ibb"),
+            # EOAS optimum cluster
+            (False, 0, "delta", "qsub -q mpi", "43.admin.default.domain"),
+            (True, 4, "delta", "qsub -q mpi", "43.admin.default.domain"),
+            (False, 0, "sigma", "qsub -q mpi", "43.admin.default.domain"),
+            (True, 4, "sigma", "qsub -q mpi", "43.admin.default.domain"),
+            (False, 0, "omega", "qsub -q mpi", "43.admin.default.domain"),
+            (True, 4, "omega", "qsub -q mpi", "43.admin.default.domain"),
         ],
     )
     def test_run_submit(
@@ -215,22 +220,20 @@ class TestRun:
     @pytest.mark.parametrize(
         "sep_xios_server, xios_servers, system, queue_job_cmd, submit_job_msg",
         [
-            (False, 0, "delta", "qsub -q mpi", "43.admin.default.domain"),
-            (True, 4, "delta", "qsub -q mpi", "43.admin.default.domain"),
+            # Alliance Canada clusters
             (False, 0, "narval", "sbatch", "Submitted batch job 43"),
             (True, 4, "narval", "sbatch", "Submitted batch job 43"),
             (False, 0, "nibi", "sbatch", "Submitted batch job 43"),
             (True, 4, "nibi", "sbatch", "Submitted batch job 43"),
+            # UBC ARC sockeye cluster
+            (False, 0, "login01", "sbatch", "Submitted batch job 43"),
+            (True, 4, "login01", "sbatch", "Submitted batch job 43"),
+            (False, 0, "login02", "sbatch", "Submitted batch job 43"),
+            (True, 4, "login02", "sbatch", "Submitted batch job 43"),
+            # MOAD development machine
             (False, 0, "salish", "bash", "bash run_dir/SalishSeaNEMO.sh started"),
             (True, 4, "salish", "bash", "bash run_dir/SalishSeaNEMO.sh started"),
-            (False, 0, "sigma", "qsub -q mpi", "43.admin.default.domain"),
-            (True, 4, "sigma", "qsub -q mpi", "43.admin.default.domain"),
-            (False, 0, "login01", "sbatch", "Submitted batch job 43"),  # sockeye
-            (True, 4, "login01", "sbatch", "Submitted batch job 43"),  # sockeye
-            (False, 0, "login02", "sbatch", "Submitted batch job 43"),  # sockeye
-            (True, 4, "login02", "sbatch", "Submitted batch job 43"),  # sockeye
-            (False, 0, "omega", "qsub -q mpi", "43.admin.default.domain"),
-            (True, 4, "omega", "qsub -q mpi", "43.admin.default.domain"),
+            # UBC Chemistry orcinus cluster
             (False, 0, "orcinus", "qsub", "43.orca2.ibb"),
             (True, 4, "orcinus", "qsub", "43.orca2.ibb"),
             (False, 0, "seawolf1", "qsub", "431.orca2.ibb"),
@@ -239,6 +242,13 @@ class TestRun:
             (True, 4, "seawolf2", "qsub", "432.orca2.ibb"),
             (False, 0, "seawolf3", "qsub", "433.orca2.ibb"),
             (True, 4, "seawolf3", "qsub", "433.orca2.ibb"),
+            # EOAS optimum cluster
+            (False, 0, "delta", "qsub -q mpi", "43.admin.default.domain"),
+            (True, 4, "delta", "qsub -q mpi", "43.admin.default.domain"),
+            (False, 0, "sigma", "qsub -q mpi", "43.admin.default.domain"),
+            (True, 4, "sigma", "qsub -q mpi", "43.admin.default.domain"),
+            (False, 0, "omega", "qsub -q mpi", "43.admin.default.domain"),
+            (True, 4, "omega", "qsub -q mpi", "43.admin.default.domain"),
         ],
     )
     def test_run_waitjob(
@@ -390,22 +400,20 @@ class TestRun:
     @pytest.mark.parametrize(
         "sep_xios_server, xios_servers, system, queue_job_cmd, submit_job_msg",
         [
-            (False, 0, "delta", "qsub -q mpi", "43.admin.default.domain"),
-            (True, 4, "delta", "qsub -q mpi", "43.admin.default.domain"),
+            # Alliance Canada clusters
             (False, 0, "narval", "sbatch", "Submitted batch job 43"),
             (True, 4, "narval", "sbatch", "Submitted batch job 43"),
             (False, 0, "nibi", "sbatch", "Submitted batch job 43"),
             (True, 4, "nibi", "sbatch", "Submitted batch job 43"),
+            # UBC ARC sockeye cluster
+            (False, 0, "login01", "sbatch", "Submitted batch job 43"),
+            (True, 4, "login01", "sbatch", "Submitted batch job 43"),
+            (False, 0, "login02", "sbatch", "Submitted batch job 43"),
+            (True, 4, "login02", "sbatch", "Submitted batch job 43"),
+            # MOAD development machine
             (False, 0, "salish", "bash", "bash run_dir/SalishSeaNEMO.sh started"),
             (True, 4, "salish", "bash", "bash run_dir/SalishSeaNEMO.sh started"),
-            (False, 0, "sigma", "qsub -q mpi", "43.admin.default.domain"),
-            (True, 4, "sigma", "qsub -q mpi", "43.admin.default.domain"),
-            (False, 0, "login01", "sbatch", "Submitted batch job 43"),  # sockeye
-            (True, 4, "login01", "sbatch", "Submitted batch job 43"),  # sockeye
-            (False, 0, "login02", "sbatch", "Submitted batch job 43"),  # sockeye
-            (True, 4, "login02", "sbatch", "Submitted batch job 43"),  # sockeye
-            (False, 0, "omega", "qsub -q mpi", "43.admin.default.domain"),
-            (True, 4, "omega", "qsub -q mpi", "43.admin.default.domain"),
+            # UBC Chemistry orcinus cluster
             (False, 0, "orcinus", "qsub", "43.orca2.ibb"),
             (True, 4, "orcinus", "qsub", "43.orca2.ibb"),
             (False, 0, "seawolf1", "qsub", "431.orca2.ibb"),
@@ -414,6 +422,13 @@ class TestRun:
             (True, 4, "seawolf2", "qsub", "432.orca2.ibb"),
             (False, 0, "seawolf3", "qsub", "433.orca2.ibb"),
             (True, 4, "seawolf3", "qsub", "433.orca2.ibb"),
+            # EOAS optimum cluster
+            (False, 0, "delta", "qsub -q mpi", "43.admin.default.domain"),
+            (True, 4, "delta", "qsub -q mpi", "43.admin.default.domain"),
+            (False, 0, "sigma", "qsub -q mpi", "43.admin.default.domain"),
+            (True, 4, "sigma", "qsub -q mpi", "43.admin.default.domain"),
+            (False, 0, "omega", "qsub -q mpi", "43.admin.default.domain"),
+            (True, 4, "omega", "qsub -q mpi", "43.admin.default.domain"),
         ],
     )
     def test_run_separate_deflate(
@@ -468,22 +483,7 @@ class TestRun:
     @pytest.mark.parametrize(
         "sep_xios_server, xios_servers, system, queue_job_cmd, job_msgs, submit_job_msg",
         [
-            (
-                False,
-                0,
-                "delta",
-                "qsub -q mpi",
-                ("43.admin.default.domain", "44.admin.default.domain"),
-                "43.admin.default.domain",
-            ),
-            (
-                True,
-                4,
-                "delta",
-                "qsub -q mpi",
-                ("43.admin.default.domain", "44.admin.default.domain"),
-                "43.admin.default.domain",
-            ),
+            # Alliance Canada clusters
             (
                 False,
                 0,
@@ -516,8 +516,60 @@ class TestRun:
                 ("Submitted batch job 43", "Submitted batch job 44"),
                 "Submitted batch job 43",
             ),
+            # UBC ARC sockeye cluster
+            (
+                False,
+                0,
+                "sockeye",
+                "qsub",
+                ("43.pbsha.ib.sockeye", "44.pbsha.ib.sockeye"),
+                "43.pbsha.ib.sockeye",
+            ),
+            (
+                True,
+                4,
+                "sockeye",
+                "qsub",
+                ("43.pbsha.ib.sockeye", "44.pbsha.ib.sockeye"),
+                "43.pbsha.ib.sockeye",
+            ),
+            # MOAD development machine
             (False, 0, "salish", "bash", ("43.master", "44.master"), "43.master"),
             (True, 4, "salish", "bash", ("43.master", "44.master"), "43.master"),
+            # UBC Chemistry orcinus cluster
+            (
+                False,
+                0,
+                "orcinus",
+                "qsub",
+                ("43.orca2.ibb", "44.orca2.ibb"),
+                "43.orca2.ibb",
+            ),
+            (
+                True,
+                4,
+                "orcinus",
+                "qsub",
+                ("43.orca2.ibb", "44.orca2.ibb"),
+                "43.orca2.ibb",
+            ),
+            # EOAS optimum cluster
+            (
+                False,
+                0,
+                "delta",
+                "qsub -q mpi",
+                ("43.admin.default.domain", "44.admin.default.domain"),
+                "43.admin.default.domain",
+            ),
+            (
+                True,
+                4,
+                "delta",
+                "qsub -q mpi",
+                ("43.admin.default.domain", "44.admin.default.domain"),
+                "43.admin.default.domain",
+            ),
             (
                 False,
                 0,
@@ -537,22 +589,6 @@ class TestRun:
             (
                 False,
                 0,
-                "sockeye",
-                "qsub",
-                ("43.pbsha.ib.sockeye", "44.pbsha.ib.sockeye"),
-                "43.pbsha.ib.sockeye",
-            ),
-            (
-                True,
-                4,
-                "sockeye",
-                "qsub",
-                ("43.pbsha.ib.sockeye", "44.pbsha.ib.sockeye"),
-                "43.pbsha.ib.sockeye",
-            ),
-            (
-                False,
-                0,
                 "omega",
                 "qsub -q mpi",
                 ("43.admin.default.domain", "44.admin.default.domain"),
@@ -565,22 +601,6 @@ class TestRun:
                 "qsub -q mpi",
                 ("43.admin.default.domain", "44.admin.default.domain"),
                 "43.admin.default.domain",
-            ),
-            (
-                False,
-                0,
-                "orcinus",
-                "qsub",
-                ("43.orca2.ibb", "44.orca2.ibb"),
-                "43.orca2.ibb",
-            ),
-            (
-                True,
-                4,
-                "orcinus",
-                "qsub",
-                ("43.orca2.ibb", "44.orca2.ibb"),
-                "43.orca2.ibb",
             ),
         ],
     )
@@ -681,22 +701,7 @@ class TestRun:
     @pytest.mark.parametrize(
         "sep_xios_server, xios_servers, system, queue_job_cmd, job_msgs, submit_job_msg",
         [
-            (
-                False,
-                0,
-                "delta",
-                "qsub -q mpi",
-                ("43.admin.default.domain", "44.admin.default.domain"),
-                "43.admin.default.domain",
-            ),
-            (
-                True,
-                4,
-                "delta",
-                "qsub -q mpi",
-                ("43.admin.default.domain", "44.admin.default.domain"),
-                "43.admin.default.domain",
-            ),
+            # Alliance Canada clusters
             (
                 False,
                 0,
@@ -729,8 +734,84 @@ class TestRun:
                 ("Submitted batch job 43", "Submitted batch job 44"),
                 "Submitted batch job 43",
             ),
+            # UBC ARC sockeye cluster
+            (
+                False,
+                0,
+                "login01",
+                "sbatch",
+                ("Submitted batch job 43", "Submitted batch job 44"),
+                "Submitted batch job 43",
+            ),
+            (
+                True,
+                4,
+                "login01",
+                "sbatch",
+                ("Submitted batch job 43", "Submitted batch job 44"),
+                "Submitted batch job 43",
+            ),
+            (
+                False,
+                0,
+                "login02",
+                "sbatch",
+                ("Submitted batch job 43", "Submitted batch job 44"),
+                "Submitted batch job 43",
+            ),
+            (
+                True,
+                4,
+                "login02",
+                "sbatch",
+                ("Submitted batch job 43", "Submitted batch job 44"),
+                "Submitted batch job 43",
+            ),
+            # MOAD development machine
             (False, 0, "salish", "bash", ("43.master", "44.master"), "43.master"),
             (True, 4, "salish", "bash", ("43.master", "44.master"), "43.master"),
+            # UBC Chemistry orcinus cluster
+            (
+                False,
+                0,
+                "orcinus",
+                "qsub",
+                ("43.orca2.ibb", "44.orca2.ibb"),
+                "43.orca2.ibb",
+            ),
+            (
+                False,
+                0,
+                "orcinus",
+                "qsub",
+                ("43.orca2.ibb", "44.orca2.ibb"),
+                "43.orca2.ibb",
+            ),
+            (
+                True,
+                4,
+                "orcinus",
+                "qsub",
+                ("43.orca2.ibb", "44.orca2.ibb"),
+                "43.orca2.ibb",
+            ),
+            # EOAS optimum cluster
+            (
+                False,
+                0,
+                "delta",
+                "qsub -q mpi",
+                ("43.admin.default.domain", "44.admin.default.domain"),
+                "43.admin.default.domain",
+            ),
+            (
+                True,
+                4,
+                "delta",
+                "qsub -q mpi",
+                ("43.admin.default.domain", "44.admin.default.domain"),
+                "43.admin.default.domain",
+            ),
             (
                 False,
                 0,
@@ -750,38 +831,6 @@ class TestRun:
             (
                 False,
                 0,
-                "login01",  # sockeye
-                "sbatch",
-                ("Submitted batch job 43", "Submitted batch job 44"),
-                "Submitted batch job 43",
-            ),
-            (
-                True,
-                4,
-                "login01",  # sockeye
-                "sbatch",
-                ("Submitted batch job 43", "Submitted batch job 44"),
-                "Submitted batch job 43",
-            ),
-            (
-                False,
-                0,
-                "login02",  # sockeye
-                "sbatch",
-                ("Submitted batch job 43", "Submitted batch job 44"),
-                "Submitted batch job 43",
-            ),
-            (
-                True,
-                4,
-                "login02",  # sockeye
-                "sbatch",
-                ("Submitted batch job 43", "Submitted batch job 44"),
-                "Submitted batch job 43",
-            ),
-            (
-                False,
-                0,
                 "omega",
                 "qsub -q mpi",
                 ("43.admin.default.domain", "44.admin.default.domain"),
@@ -794,30 +843,6 @@ class TestRun:
                 "qsub -q mpi",
                 ("43.admin.default.domain", "44.admin.default.domain"),
                 "43.admin.default.domain",
-            ),
-            (
-                False,
-                0,
-                "orcinus",
-                "qsub",
-                ("43.orca2.ibb", "44.orca2.ibb"),
-                "43.orca2.ibb",
-            ),
-            (
-                False,
-                0,
-                "orcinus",
-                "qsub",
-                ("43.orca2.ibb", "44.orca2.ibb"),
-                "43.orca2.ibb",
-            ),
-            (
-                True,
-                4,
-                "orcinus",
-                "qsub",
-                ("43.orca2.ibb", "44.orca2.ibb"),
-                "43.orca2.ibb",
             ),
         ],
     )
@@ -3020,28 +3045,33 @@ class TestDefinitions:
     @pytest.mark.parametrize(
         "system, home, deflate",
         [
-            ("delta", "${PBS_O_HOME}", True),
-            ("delta", "${PBS_O_HOME}", False),
+            # Alliance Canada clusters
             ("narval", "${HOME}/.local", True),
             ("narval", "${HOME}/.local", False),
             ("nibi", "${HOME}/.local", True),
             ("nibi", "${HOME}/.local", False),
-            ("omega", "${PBS_O_HOME}", True),
-            ("omega", "${PBS_O_HOME}", False),
-            ("orcinus", "${PBS_O_HOME}/.local", True),
-            ("orcinus", "${PBS_O_HOME}/.local", False),
+            # UBC ARC sockeye cluster
+            ("sockeye", "${HOME}/.local", True),
+            ("sockeye", "${HOME}/.local", False),
+            # MOAD development machine
             ("salish", "${HOME}/.local", True),
             ("salish", "${HOME}/.local", False),
+            # UBC Chemistry orcinus cluster
+            ("orcinus", "${PBS_O_HOME}/.local", True),
+            ("orcinus", "${PBS_O_HOME}/.local", False),
             ("seawolf1", "${PBS_O_HOME}/.local", True),
             ("seawolf1", "${PBS_O_HOME}/.local", False),
             ("seawolf2", "${PBS_O_HOME}/.local", True),
             ("seawolf2", "${PBS_O_HOME}/.local", False),
             ("seawolf3", "${PBS_O_HOME}/.local", True),
             ("seawolf3", "${PBS_O_HOME}/.local", False),
+            # EOAS optimum cluster
+            ("delta", "${PBS_O_HOME}", True),
+            ("delta", "${PBS_O_HOME}", False),
+            ("omega", "${PBS_O_HOME}", True),
+            ("omega", "${PBS_O_HOME}", False),
             ("sigma", "${PBS_O_HOME}", True),
             ("sigma", "${PBS_O_HOME}", False),
-            ("sockeye", "${HOME}/.local", True),
-            ("sockeye", "${HOME}/.local", False),
         ],
     )
     def test_definitions(self, system, home, deflate):
@@ -3164,12 +3194,24 @@ class TestExecute:
     @pytest.mark.parametrize(
         "system, mpirun_cmd",
         [
+            # Alliance Canada clusters
+            ("narval", "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe"),
+            # UBC ARC sockeye cluster
+            (
+                "login01",
+                "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe",
+            ),
+            (
+                "login02",
+                "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe",
+            ),
+            # UBC Chemistry orcinus cluster
+            ("orcinus", "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe"),
+            # EOAS optimum cluster
             (
                 "delta",
                 "mpiexec -hostfile $(openmpi_nodefile) --bind-to core -np 42 ./nemo.exe : --bind-to core -np 1 ./xios_server.exe",
             ),
-            ("narval", "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe"),
-            ("orcinus", "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe"),
             (
                 "omega",
                 "mpiexec -hostfile $(openmpi_nodefile) --bind-to core -np 42 ./nemo.exe : --bind-to core -np 1 ./xios_server.exe",
@@ -3178,14 +3220,6 @@ class TestExecute:
                 "sigma",
                 "mpiexec -hostfile $(openmpi_nodefile) --bind-to core -np 42 ./nemo.exe : --bind-to core -np 1 ./xios_server.exe",
             ),
-            (
-                "login01",
-                "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe",
-            ),  # sockeye
-            (
-                "login02",
-                "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe",
-            ),  # sockeye
         ],
     )
     def test_execute_with_deflate(self, system, mpirun_cmd, monkeypatch):
@@ -3300,24 +3334,7 @@ class TestExecute:
     @pytest.mark.parametrize(
         "system, mpirun_cmd, deflate, separate_deflate",
         [
-            (
-                "delta",
-                "mpiexec -hostfile $(openmpi_nodefile) --bind-to core -np 42 ./nemo.exe : --bind-to core -np 1 ./xios_server.exe",
-                False,
-                True,
-            ),
-            (
-                "delta",
-                "mpiexec -hostfile $(openmpi_nodefile) --bind-to core -np 42 ./nemo.exe : --bind-to core -np 1 ./xios_server.exe",
-                False,
-                False,
-            ),
-            (
-                "delta",
-                "mpiexec -hostfile $(openmpi_nodefile) --bind-to core -np 42 ./nemo.exe : --bind-to core -np 1 ./xios_server.exe",
-                True,
-                True,
-            ),
+            # Alliance Canada clusters
             (
                 "narval",
                 "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe",
@@ -3330,24 +3347,44 @@ class TestExecute:
                 False,
                 False,
             ),
+            # UBC ARC sockeye cluster
             (
-                "omega",
-                "mpiexec -hostfile $(openmpi_nodefile) --bind-to core -np 42 ./nemo.exe : --bind-to core -np 1 ./xios_server.exe",
+                "login01",
+                "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe",
                 False,
                 True,
             ),
             (
-                "omega",
-                "mpiexec -hostfile $(openmpi_nodefile) --bind-to core -np 42 ./nemo.exe : --bind-to core -np 1 ./xios_server.exe",
+                "login01",
+                "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe",
                 False,
                 False,
             ),
             (
-                "omega",
-                "mpiexec -hostfile $(openmpi_nodefile) --bind-to core -np 42 ./nemo.exe : --bind-to core -np 1 ./xios_server.exe",
+                "login01",
+                "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe",
                 True,
                 True,
             ),
+            (
+                "login02",
+                "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe",
+                False,
+                True,
+            ),
+            (
+                "login02",
+                "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe",
+                False,
+                False,
+            ),
+            (
+                "login02",
+                "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe",
+                True,
+                True,
+            ),
+            # UBC Chemistry orcinus cluster
             (
                 "orcinus",
                 "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe",
@@ -3367,6 +3404,42 @@ class TestExecute:
                 True,
             ),
             (
+                "delta",
+                "mpiexec -hostfile $(openmpi_nodefile) --bind-to core -np 42 ./nemo.exe : --bind-to core -np 1 ./xios_server.exe",
+                False,
+                True,
+            ),
+            (
+                "delta",
+                "mpiexec -hostfile $(openmpi_nodefile) --bind-to core -np 42 ./nemo.exe : --bind-to core -np 1 ./xios_server.exe",
+                False,
+                False,
+            ),
+            (
+                "delta",
+                "mpiexec -hostfile $(openmpi_nodefile) --bind-to core -np 42 ./nemo.exe : --bind-to core -np 1 ./xios_server.exe",
+                True,
+                True,
+            ),
+            (
+                "omega",
+                "mpiexec -hostfile $(openmpi_nodefile) --bind-to core -np 42 ./nemo.exe : --bind-to core -np 1 ./xios_server.exe",
+                False,
+                True,
+            ),
+            (
+                "omega",
+                "mpiexec -hostfile $(openmpi_nodefile) --bind-to core -np 42 ./nemo.exe : --bind-to core -np 1 ./xios_server.exe",
+                False,
+                False,
+            ),
+            (
+                "omega",
+                "mpiexec -hostfile $(openmpi_nodefile) --bind-to core -np 42 ./nemo.exe : --bind-to core -np 1 ./xios_server.exe",
+                True,
+                True,
+            ),
+            (
                 "sigma",
                 "mpiexec -hostfile $(openmpi_nodefile) --bind-to core -np 42 ./nemo.exe : --bind-to core -np 1 ./xios_server.exe",
                 False,
@@ -3381,42 +3454,6 @@ class TestExecute:
             (
                 "sigma",
                 "mpiexec -hostfile $(openmpi_nodefile) --bind-to core -np 42 ./nemo.exe : --bind-to core -np 1 ./xios_server.exe",
-                True,
-                True,
-            ),
-            (
-                "login01",  # sockeye
-                "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe",
-                False,
-                True,
-            ),
-            (
-                "login01",  # sockeye
-                "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe",
-                False,
-                False,
-            ),
-            (
-                "login01",  # sockeye
-                "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe",
-                True,
-                True,
-            ),
-            (
-                "login02",  # sockeye
-                "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe",
-                False,
-                True,
-            ),
-            (
-                "login02",  # sockeye
-                "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe",
-                False,
-                False,
-            ),
-            (
-                "login02",  # sockeye
-                "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe",
                 True,
                 True,
             ),

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -136,6 +136,8 @@ class TestRun:
         "sep_xios_server, xios_servers, system, queue_job_cmd, submit_job_msg",
         [
             # Alliance Canada clusters
+            (False, 0, "fir", "sbatch", "Submitted batch job 43"),
+            (True, 4, "fir", "sbatch", "Submitted batch job 43"),
             (False, 0, "narval", "sbatch", "Submitted batch job 43"),
             (True, 4, "narval", "sbatch", "Submitted batch job 43"),
             (False, 0, "nibi", "sbatch", "Submitted batch job 43"),
@@ -221,6 +223,8 @@ class TestRun:
         "sep_xios_server, xios_servers, system, queue_job_cmd, submit_job_msg",
         [
             # Alliance Canada clusters
+            (False, 0, "fir", "sbatch", "Submitted batch job 43"),
+            (True, 4, "fir", "sbatch", "Submitted batch job 43"),
             (False, 0, "narval", "sbatch", "Submitted batch job 43"),
             (True, 4, "narval", "sbatch", "Submitted batch job 43"),
             (False, 0, "nibi", "sbatch", "Submitted batch job 43"),
@@ -401,6 +405,8 @@ class TestRun:
         "sep_xios_server, xios_servers, system, queue_job_cmd, submit_job_msg",
         [
             # Alliance Canada clusters
+            (False, 0, "fir", "sbatch", "Submitted batch job 43"),
+            (True, 4, "fir", "sbatch", "Submitted batch job 43"),
             (False, 0, "narval", "sbatch", "Submitted batch job 43"),
             (True, 4, "narval", "sbatch", "Submitted batch job 43"),
             (False, 0, "nibi", "sbatch", "Submitted batch job 43"),
@@ -484,6 +490,22 @@ class TestRun:
         "sep_xios_server, xios_servers, system, queue_job_cmd, job_msgs, submit_job_msg",
         [
             # Alliance Canada clusters
+            (
+                False,
+                0,
+                "fir",
+                "sbatch",
+                ("Submitted batch job 43", "Submitted batch job 44"),
+                "Submitted batch job 43",
+            ),
+            (
+                True,
+                4,
+                "fir",
+                "sbatch",
+                ("Submitted batch job 43", "Submitted batch job 44"),
+                "Submitted batch job 43",
+            ),
             (
                 False,
                 0,
@@ -702,6 +724,22 @@ class TestRun:
         "sep_xios_server, xios_servers, system, queue_job_cmd, job_msgs, submit_job_msg",
         [
             # Alliance Canada clusters
+            (
+                False,
+                0,
+                "fir",
+                "sbatch",
+                ("Submitted batch job 43", "Submitted batch job 44"),
+                "Submitted batch job 43",
+            ),
+            (
+                True,
+                4,
+                "fir",
+                "sbatch",
+                ("Submitted batch job 43", "Submitted batch job 44"),
+                "Submitted batch job 43",
+            ),
             (
                 False,
                 0,
@@ -2006,6 +2044,110 @@ class TestBuildBatchScript:
     """Unit test for _build_batch_script() function."""
 
     @pytest.mark.parametrize("deflate", [True, False])
+    def test_fir(self, deflate, monkeypatch):
+        desc_file = StringIO(
+            "run_id: foo\n" "walltime: 01:02:03\n" "email: me@example.com"
+        )
+        run_desc = yaml.safe_load(desc_file)
+        monkeypatch.setattr(salishsea_cmd.run, "SYSTEM", "fir")
+
+        script = salishsea_cmd.run._build_batch_script(
+            run_desc,
+            Path("SalishSea.yaml"),
+            nemo_processors=42,
+            xios_processors=1,
+            max_deflate_jobs=4,
+            results_dir=Path("results_dir"),
+            run_dir=Path("tmp_run_dir"),
+            deflate=deflate,
+            separate_deflate=False,
+            cores_per_node="",
+            cpu_arch="",
+        )
+
+        expected = textwrap.dedent(
+            f"""\
+            #!/bin/bash
+
+            #SBATCH --job-name=foo
+            #SBATCH --nodes=1
+            #SBATCH --ntasks-per-node=192
+            #SBATCH --mem=0
+            #SBATCH --time=1:02:03
+            #SBATCH --mail-user=me@example.com
+            #SBATCH --mail-type=ALL
+            #SBATCH --account=def-allen
+            # stdout and stderr file paths/names
+            #SBATCH --output=results_dir/stdout
+            #SBATCH --error=results_dir/stderr
+
+
+            RUN_ID="foo"
+            RUN_DESC="tmp_run_dir/SalishSea.yaml"
+            WORK_DIR="tmp_run_dir"
+            RESULTS_DIR="results_dir"
+            COMBINE="${{HOME}}/.local/bin/salishsea combine"
+            """
+        )
+        if deflate:
+            expected += textwrap.dedent(
+                """\
+                DEFLATE="${HOME}/.local/bin/salishsea deflate"
+                """
+            )
+        expected += textwrap.dedent(
+            """\
+            GATHER="${HOME}/.local/bin/salishsea gather"
+
+            module load StdEnv/2023
+            module load netcdf-fortran-mpi/4.6.1
+
+            mkdir -p ${RESULTS_DIR}
+            cd ${WORK_DIR}
+            echo "working dir: $(pwd)"
+
+            echo "Starting run at $(date)"
+            mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe
+            MPIRUN_EXIT_CODE=$?
+            echo "Ended run at $(date)"
+
+            echo "Results combining started at $(date)"
+            ${COMBINE} ${RUN_DESC} --debug
+            echo "Results combining ended at $(date)"
+            """
+        )
+        if deflate:
+            expected += textwrap.dedent(
+                """\
+
+                echo "Results deflation started at $(date)"
+                module load nco/4.9.5
+                ${DEFLATE} *_ptrc_T*.nc *_prod_T*.nc *_carp_T*.nc *_grid_[TUVW]*.nc \\
+                  *_turb_T*.nc *_dia[12n]_T*.nc FVCOM*.nc Slab_[UV]*.nc *_mtrc_T*.nc \\
+                  --jobs 4 --debug
+                echo "Results deflation ended at $(date)"
+                """
+            )
+        expected += textwrap.dedent(
+            """\
+
+            echo "Results gathering started at $(date)"
+            ${GATHER} ${RESULTS_DIR} --debug
+            echo "Results gathering ended at $(date)"
+
+            chmod go+rx ${RESULTS_DIR}
+            chmod g+rw ${RESULTS_DIR}/*
+            chmod o+r ${RESULTS_DIR}/*
+
+            echo "Deleting run directory" >>${RESULTS_DIR}/stdout
+            rmdir $(pwd)
+            echo "Finished at $(date)" >>${RESULTS_DIR}/stdout
+            exit ${MPIRUN_EXIT_CODE}
+            """
+        )
+        assert script == expected
+
+    @pytest.mark.parametrize("deflate", [True, False])
     def test_narval(self, deflate, monkeypatch):
         desc_file = StringIO(
             "run_id: foo\n" "walltime: 01:02:03\n" "email: me@example.com"
@@ -2704,6 +2846,43 @@ class TestBuildBatchScript:
 class TestSbatchDirectives:
     """Unit tests for _sbatch_directives() function."""
 
+    def test_fir_sbatch_directives(self, caplog, monkeypatch):
+        desc_file = StringIO("run_id: foo\n" "walltime: 01:02:03\n")
+        run_desc = yaml.safe_load(desc_file)
+        monkeypatch.setattr(salishsea_cmd.run, "SYSTEM", "fir")
+        caplog.set_level(logging.DEBUG)
+
+        slurm_directives = salishsea_cmd.run._sbatch_directives(
+            run_desc,
+            n_processors=43,
+            procs_per_node=192,
+            cpu_arch="",
+            email="me@example.com",
+            results_dir=Path("foo"),
+        )
+
+        assert caplog.records[0].levelname == "INFO"
+        expected = (
+            f"No account found in run description YAML file, "
+            f"so assuming def-allen. If sbatch complains you can specify a "
+            f"different account with a YAML line like account: def-allen"
+        )
+        assert caplog.records[0].message == expected
+        expected = (
+            "#SBATCH --job-name=foo\n"
+            "#SBATCH --nodes=1\n"
+            "#SBATCH --ntasks-per-node=192\n"
+            "#SBATCH --mem=0\n"
+            "#SBATCH --time=1:02:03\n"
+            "#SBATCH --mail-user=me@example.com\n"
+            "#SBATCH --mail-type=ALL\n"
+            "#SBATCH --account=def-allen\n"
+            "# stdout and stderr file paths/names\n"
+            "#SBATCH --output=foo/stdout\n"
+            "#SBATCH --error=foo/stderr\n"
+        )
+        assert slurm_directives == expected
+
     def test_narval_sbatch_directives(self, caplog, monkeypatch):
         desc_file = StringIO("run_id: foo\n" "walltime: 01:02:03\n")
         run_desc = yaml.safe_load(desc_file)
@@ -3046,6 +3225,8 @@ class TestDefinitions:
         "system, home, deflate",
         [
             # Alliance Canada clusters
+            ("fir", "${HOME}/.local", True),
+            ("fir", "${HOME}/.local", False),
             ("narval", "${HOME}/.local", True),
             ("narval", "${HOME}/.local", False),
             ("nibi", "${HOME}/.local", True),
@@ -3126,8 +3307,9 @@ class TestModules:
         )
         assert modules == expected
 
-    def test_nibi(self, monkeypatch):
-        monkeypatch.setattr(salishsea_cmd.run, "SYSTEM", "nibi")
+    @pytest.mark.parametrize("system", ["fir", "nibi"])
+    def test_2025_alliance_cluster(self, system, monkeypatch):
+        monkeypatch.setattr(salishsea_cmd.run, "SYSTEM", system)
 
         modules = salishsea_cmd.run._modules()
 
@@ -3267,7 +3449,7 @@ class TestExecute:
             echo "Results deflation started at $(date)"
             """
         )
-        if system in {"nibi", "narval"}:
+        if system in {"fir", "nibi", "narval"}:
             expected += textwrap.dedent(
                 """\
                 module load nco/4.9.5
@@ -3335,6 +3517,12 @@ class TestExecute:
         "system, mpirun_cmd, deflate, separate_deflate",
         [
             # Alliance Canada clusters
+            (
+                "fir",
+                "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe",
+                False,
+                False,
+            ),
             (
                 "narval",
                 "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe",


### PR DESCRIPTION
* Add support for Alliance Canada `fir` HPC system.
* Reorganize system-specific elements in the `run` plug-in module and its tests,
   grouping them by the systems to which they apply instead of simply in alphabetical order.