### PR TITLE
Add support for `trillium` HPC system

### DIFF
--- a/salishsea_cmd/run.py
+++ b/salishsea_cmd/run.py
@@ -663,6 +663,7 @@ def _build_batch_script(
         "fir",
         "narval",
         "nibi",
+        "trillium",
         # UBC ARC sockeye cluster
         "sockeye",
     }:
@@ -671,6 +672,7 @@ def _build_batch_script(
             "fir": 192 if not cores_per_node else int(cores_per_node),
             "narval": 64 if not cores_per_node else int(cores_per_node),
             "nibi": 192 if not cores_per_node else int(cores_per_node),
+            "trillium": 192 if not cores_per_node else int(cores_per_node),
             # UBC ARC sockeye cluster
             "sockeye": 40 if not cores_per_node else int(cores_per_node),
         }[SYSTEM]
@@ -775,6 +777,7 @@ def _sbatch_directives(
         "fir": "0",
         "narval": "0",
         "nibi": "0",
+        "trillium": "0",
         # UBC ARC sockeye cluster
         "sockeye": "186gb",
     }.get(SYSTEM, mem)
@@ -968,6 +971,7 @@ def _definitions(run_desc, run_desc_file, run_dir, results_dir, deflate):
         "fir": Path("${HOME}", ".local", "bin", "salishsea"),
         "narval": Path("${HOME}", ".local", "bin", "salishsea"),
         "nibi": Path("${HOME}", ".local", "bin", "salishsea"),
+        "trillium": Path("${HOME}", ".local", "bin", "salishsea"),
         # UBC ARC sockeye cluster
         "sockeye": Path("${HOME}", ".local", "bin", "salishsea"),
         # MOAD development machine
@@ -999,6 +1003,12 @@ def _modules():
     modules = {
         # Alliance Canada clusters
         "fir": textwrap.dedent(
+            """\
+            module load StdEnv/2023
+            module load netcdf-fortran-mpi/4.6.1
+            """
+        ),
+        "trillium": textwrap.dedent(
             """\
             module load StdEnv/2023
             module load netcdf-fortran-mpi/4.6.1
@@ -1110,6 +1120,7 @@ def _execute(
         "fir": "mpirun",
         "narval": "mpirun",
         "nibi": "mpirun",
+        "trillium": "mpirun",
         # UBC ARC sockeye cluster
         "sockeye": "mpirun",
         # MOAD development machine
@@ -1129,6 +1140,7 @@ def _execute(
         "fir": f"{mpirun} -np {nemo_processors} ./nemo.exe",
         "narval": f"{mpirun} -np {nemo_processors} ./nemo.exe",
         "nibi": f"{mpirun} -np {nemo_processors} ./nemo.exe",
+        "trillium": f"{mpirun} -np {nemo_processors} ./nemo.exe",
         # UBC ARC sockeye cluster
         "sockeye": f"{mpirun} -np {nemo_processors} ./nemo.exe",
         # MOAD development machine
@@ -1149,6 +1161,7 @@ def _execute(
             "fir": f"{mpirun} : -np {xios_processors} ./xios_server.exe{redirect}",
             "narval": f"{mpirun} : -np {xios_processors} ./xios_server.exe{redirect}",
             "nibi": f"{mpirun} : -np {xios_processors} ./xios_server.exe{redirect}",
+            "trillium": f"{mpirun} : -np {xios_processors} ./xios_server.exe{redirect}",
             # UBC ARC sockeye cluster
             "sockeye": f"{mpirun} : -np {xios_processors} ./xios_server.exe{redirect}",
             # MOAD development machine
@@ -1208,7 +1221,7 @@ def _execute(
             echo "Results deflation started at $(date)"{redirect}
             """
         )
-        if SYSTEM in {"fir", "narval", "nibi"}:
+        if SYSTEM in {"fir", "narval", "nibi", "trillium"}:
             # Load the nco module just before deflation because it replaces
             # the netcdf-mpi and netcdf-fortran-mpi modules with their non-mpi
             # variants

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -2222,6 +2222,110 @@ class TestBuildBatchScript:
         assert script == expected
 
     @pytest.mark.parametrize("deflate", [True, False])
+    def test_trillium(self, deflate, monkeypatch):
+        desc_file = StringIO(
+            "run_id: foo\n" "walltime: 01:02:03\n" "email: me@example.com"
+        )
+        run_desc = yaml.safe_load(desc_file)
+        monkeypatch.setattr(salishsea_cmd.run, "SYSTEM", "trillium")
+
+        script = salishsea_cmd.run._build_batch_script(
+            run_desc,
+            Path("SalishSea.yaml"),
+            nemo_processors=42,
+            xios_processors=1,
+            max_deflate_jobs=4,
+            results_dir=Path("results_dir"),
+            run_dir=Path("tmp_run_dir"),
+            deflate=deflate,
+            separate_deflate=False,
+            cores_per_node="",
+            cpu_arch="",
+        )
+
+        expected = textwrap.dedent(
+            f"""\
+            #!/bin/bash
+
+            #SBATCH --job-name=foo
+            #SBATCH --nodes=1
+            #SBATCH --ntasks-per-node=192
+            #SBATCH --mem=0
+            #SBATCH --time=1:02:03
+            #SBATCH --mail-user=me@example.com
+            #SBATCH --mail-type=ALL
+            #SBATCH --account=def-allen
+            # stdout and stderr file paths/names
+            #SBATCH --output=results_dir/stdout
+            #SBATCH --error=results_dir/stderr
+
+
+            RUN_ID=\"foo\"
+            RUN_DESC=\"tmp_run_dir/SalishSea.yaml\"
+            WORK_DIR=\"tmp_run_dir\"
+            RESULTS_DIR=\"results_dir\"
+            COMBINE=\"${{HOME}}/.local/bin/salishsea combine\"
+            """
+        )
+        if deflate:
+            expected += textwrap.dedent(
+                """\
+                DEFLATE=\"${HOME}/.local/bin/salishsea deflate\"
+                """
+            )
+        expected += textwrap.dedent(
+            """\
+            GATHER=\"${HOME}/.local/bin/salishsea gather\"
+
+            module load StdEnv/2023
+            module load netcdf-fortran-mpi/4.6.1
+
+            mkdir -p ${RESULTS_DIR}
+            cd ${WORK_DIR}
+            echo \"working dir: $(pwd)\"
+
+            echo \"Starting run at $(date)\"
+            mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe
+            MPIRUN_EXIT_CODE=$?
+            echo \"Ended run at $(date)\"
+
+            echo \"Results combining started at $(date)\"
+            ${COMBINE} ${RUN_DESC} --debug
+            echo \"Results combining ended at $(date)\"
+            """
+        )
+        if deflate:
+            expected += textwrap.dedent(
+                """\
+
+                echo \"Results deflation started at $(date)\"
+                module load nco/4.9.5
+                ${DEFLATE} *_ptrc_T*.nc *_prod_T*.nc *_carp_T*.nc *_grid_[TUVW]*.nc \\
+                  *_turb_T*.nc *_dia[12n]_T*.nc FVCOM*.nc Slab_[UV]*.nc *_mtrc_T*.nc \\
+                  --jobs 4 --debug
+                echo \"Results deflation ended at $(date)\"
+                """
+            )
+        expected += textwrap.dedent(
+            """\
+
+            echo \"Results gathering started at $(date)\"
+            ${GATHER} ${RESULTS_DIR} --debug
+            echo \"Results gathering ended at $(date)\"
+
+            chmod go+rx ${RESULTS_DIR}
+            chmod g+rw ${RESULTS_DIR}/*
+            chmod o+r ${RESULTS_DIR}/*
+
+            echo \"Deleting run directory\" >>${RESULTS_DIR}/stdout
+            rmdir $(pwd)
+            echo \"Finished at $(date)\" >>${RESULTS_DIR}/stdout
+            exit ${MPIRUN_EXIT_CODE}
+            """
+        )
+        assert script == expected
+
+    @pytest.mark.parametrize("deflate", [True, False])
     def test_narval(self, deflate, monkeypatch):
         desc_file = StringIO(
             "run_id: foo\n" "walltime: 01:02:03\n" "email: me@example.com"
@@ -2953,6 +3057,43 @@ class TestSbatchDirectives:
         )
         assert slurm_directives == expected
 
+    def test_trillium_sbatch_directives(self, caplog, monkeypatch):
+        desc_file = StringIO("run_id: foo\n" "walltime: 01:02:03\n")
+        run_desc = yaml.safe_load(desc_file)
+        monkeypatch.setattr(salishsea_cmd.run, "SYSTEM", "trillium")
+        caplog.set_level(logging.DEBUG)
+
+        slurm_directives = salishsea_cmd.run._sbatch_directives(
+            run_desc,
+            n_processors=43,
+            procs_per_node=192,
+            cpu_arch="",
+            email="me@example.com",
+            results_dir=Path("foo"),
+        )
+
+        assert caplog.records[0].levelname == "INFO"
+        expected = (
+            f"No account found in run description YAML file, "
+            f"so assuming def-allen. If sbatch complains you can specify a "
+            f"different account with a YAML line like account: def-allen"
+        )
+        assert caplog.records[0].message == expected
+        expected = (
+            "#SBATCH --job-name=foo\n"
+            "#SBATCH --nodes=1\n"
+            "#SBATCH --ntasks-per-node=192\n"
+            "#SBATCH --mem=0\n"
+            "#SBATCH --time=1:02:03\n"
+            "#SBATCH --mail-user=me@example.com\n"
+            "#SBATCH --mail-type=ALL\n"
+            "#SBATCH --account=def-allen\n"
+            "# stdout and stderr file paths/names\n"
+            "#SBATCH --output=foo/stdout\n"
+            "#SBATCH --error=foo/stderr\n"
+        )
+        assert slurm_directives == expected
+
     def test_narval_sbatch_directives(self, caplog, monkeypatch):
         desc_file = StringIO("run_id: foo\n" "walltime: 01:02:03\n")
         run_desc = yaml.safe_load(desc_file)
@@ -3300,6 +3441,8 @@ class TestDefinitions:
             ("narval", "${HOME}/.local", False),
             ("nibi", "${HOME}/.local", True),
             ("nibi", "${HOME}/.local", False),
+            ("trillium", "${HOME}/.local", True),
+            ("trillium", "${HOME}/.local", False),
             # UBC ARC sockeye cluster
             ("sockeye", "${HOME}/.local", True),
             ("sockeye", "${HOME}/.local", False),
@@ -3376,7 +3519,7 @@ class TestModules:
         )
         assert modules == expected
 
-    @pytest.mark.parametrize("system", ["fir", "nibi"])
+    @pytest.mark.parametrize("system", ["fir", "nibi", "trillium"])
     def test_2025_alliance_cluster(self, system, monkeypatch):
         monkeypatch.setattr(salishsea_cmd.run, "SYSTEM", system)
 
@@ -3513,7 +3656,7 @@ class TestExecute:
             echo "Results deflation started at $(date)"
             """
         )
-        if system in {"fir", "nibi", "narval"}:
+        if system in {"fir", "nibi", "narval", "trillium"}:
             expected += textwrap.dedent(
                 """\
                 module load nco/4.9.5


### PR DESCRIPTION
Configured the `trillium` cluster with batch job submission via `sbatch`, processor settings, and module setup. Updated relevant tests to validate functionality, including batch script generation and account handling for `trillium`.

The changes in this commit were produced by the PyCharm Junie AI agent in response to the instructions:
   Please add support for a new HPC system called trillium using the support for
   the system call fir for guidance. Please update the run.py and test_run.py
   modules.
I had to make 2 minor edits concerning escaping of `{}` characters around envvars in test results expectation strings to get the generated tests to pass.

Preliminary inspection of the code that Junie generated shows that it is very similar to the code I wrote to add support for `fir`.