### PR TITLE
Update Sphinx documentation for `sphinx_copybutton` compatibility

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,6 +84,15 @@ source_suffix = {".rst": "restructuredtext"}
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 
+# -- Options for sphinx_copybutton extension ------------------------------
+
+copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
+copybutton_prompt_is_regexp = True
+copybutton_line_continuation_character = "\\"
+# Add a `no-copybutton` class that can be used to suppress the copy button
+copybutton_selector = "div:not(.no-copybutton) > div.highlight > pre"
+
+
 # -- Options for HTML output ----------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -43,10 +43,10 @@ a working environment the first time that you use a `Pixi`_ command in the :file
 (or a sub-directory).
 Example:
 
-.. code-block:: bash
+.. code-block:: console
 
-    cd SalishSeaCmd
-    pixi run salishsea help
+    $ cd SalishSeaCmd
+    $ pixi run salishsea help
 
 A common use-case is to execute the :command:`salishsea run` command in the directory containing
 your run description YAML file.
@@ -56,11 +56,11 @@ correct environment.
 We do that by using the ``-m`` or ``--manifest`` option of :command:`pixi run`.
 Example:
 
-.. code-block:: bash
+.. code-block:: console
 
-    cd SS-run-sets/SalishSea/sea/Carbon_v202111/
-    pixi run -m $HOME/MEOPAR/SalishSeaCmd salishsea run 01jan11_Lb80.yaml \
-      /scratch/allen/Carbon/MoreSens/Now/01jan11/
+    $ cd SS-run-sets/SalishSea/sea/Carbon_v202111/
+    $ pixi run -m $HOME/MEOPAR/SalishSeaCmd salishsea run 01jan11_Lb80.yaml \
+        /scratch/allen/Carbon/MoreSens/Now/01jan11/
 
 For doing so it development,
 testing,

--- a/docs/pkg_development.rst
+++ b/docs/pkg_development.rst
@@ -248,6 +248,7 @@ To do a clean build of the documentation use:
 The output looks something like:
 
 .. code-block:: text
+   :class: no-copybutton
 
     ✨ Pixi task (docs in docs): make clean html
     Removing everything under '_build'...
@@ -312,6 +313,7 @@ Run the link checker with:
 The output looks something like:
 
 .. code-block:: text
+   :class: no-copybutton
 
     ✨ Pixi task (linkcheck in docs): make clean linkcheck
     Removing everything under '_build'...
@@ -441,6 +443,7 @@ to run the test suite.
 The output looks something like:
 
 .. code-block:: text
+   :class: no-copybutton
 
     ================================= test session starts ===================================
     platform linux -- Python 3.14.2, pytest-9.0.2, pluggy-1.6.0

--- a/docs/pkg_development.rst
+++ b/docs/pkg_development.rst
@@ -104,9 +104,9 @@ Clone the :ref:`SalishSeaCmd-repo` code and documentation `repository`_ from Git
 
 .. _repository: https://github.com/SalishSeaCast/SalishSeaCmd
 
-.. code-block:: bash
+.. code-block:: console
 
-    git clone git@github.com:SalishSeaCast/SalishSeaCmd.git
+    $ git clone git@github.com:SalishSeaCast/SalishSeaCmd.git
 
 
 .. _SalishSeaCmdDevelopmentEnvironment:
@@ -181,10 +181,10 @@ and repo QA.
 To install the `pre-commit` hooks in a newly cloned repo,
 run :command:`pre-commit install`:
 
-.. code-block:: bash
+.. code-block:: console
 
-    cd SalishSeaCmd
-    pixi run -e dev pre-commit install
+    $ cd SalishSeaCmd
+    $ pixi run -e dev pre-commit install
 
 .. note::
     You only need to install the hooks once immediately after you make a new clone

--- a/docs/pkg_development.rst
+++ b/docs/pkg_development.rst
@@ -240,10 +240,10 @@ Building and Previewing the Documentation
 Building the documentation is driven by :file:`docs/Makefile`.
 To do a clean build of the documentation use:
 
-.. code-block:: bash
+.. code-block:: console
 
-    cd SalishSeaCmd/
-    pixi run docs
+    $ cd SalishSeaCmd/
+    $ pixi run docs
 
 The output looks something like:
 
@@ -304,10 +304,10 @@ Link Checking the Documentation
 Sphinx also provides a link checker utility which can be run to find broken or redirected links in the docs.
 Run the link checker with:
 
-.. code-block:: bash
+.. code-block:: console
 
-    cd SalishSeaCmd/
-    pixi run linkcheck
+    $ cd SalishSeaCmd/
+    $ pixi run linkcheck
 
 The output looks something like:
 
@@ -432,10 +432,10 @@ The `pytest`_ tool is used for test fixtures and as the test runner for the suit
 
 To run the test suite in the most recent supported version of Python use:
 
-.. code-block:: bash
+.. code-block:: console
 
-    cd SalishSeaCmd/
-    pixi run -e test pytest
+    $ cd SalishSeaCmd/
+    $ pixi run -e test pytest
 
 to run the test suite.
 The output looks something like:
@@ -464,20 +464,20 @@ You can monitor what lines of code the test suite exercises using the `coverage.
 .. _coverage.py: https://coverage.readthedocs.io/en/latest/
 .. _pytest-cov: https://pytest-cov.readthedocs.io/en/latest/
 
-.. code-block:: bash
+.. code-block:: console
 
-    cd SalishSeaCmd/
-    pixi run -e test pytest-cov
+    $ cd SalishSeaCmd/
+    $ pixi run -e test pytest-cov
 
 The test coverage report will be displayed below the test suite run output.
 
 Alternatively,
 you can use
 
-.. code-block:: bash
+.. code-block:: console
 
-    cd SalishSeaCmd/
-    pixi run -e test pytest-cov-html
+    $ cd SalishSeaCmd/
+    $ pixi run -e test pytest-cov-html
 
 to produce an HTML report that you can view in your browser by opening
 :file:`SalishSeaCmd/htmlcov/index.html`.

--- a/docs/run_description_file/3.6_yaml_file.rst
+++ b/docs/run_description_file/3.6_yaml_file.rst
@@ -518,11 +518,11 @@ the files created will be::
 For Git repositories,
 each :file:`_rev.txt` file will contain the output of the commands:
 
-.. code-block:: bash
+.. code-block:: console
 
-    git branch --show-current
-    git log -1
-    git show --pretty="" --name-only
+    $ git branch --show-current
+    $ git log -1
+    $ git show --pretty="" --name-only
 
 for the repository.
 That is a record of the last committed revision of the repository that will be in effect for the run.

--- a/docs/subcommands.rst
+++ b/docs/subcommands.rst
@@ -26,39 +26,38 @@ The command :command:`pixi run salishsea help` produces a list of the available 
 options and sub-commands:
 
 .. code-block:: text
+   :class: no-copybutton
 
-  usage: salishsea [--version] [-v | -q] [--log-file LOG_FILE] [-h] [--debug]
+    usage: salishsea [--version] [-v | -q] [--log-file LOG_FILE] [-h] [--debug]
 
-  SalishSeaCast NEMO Command Processor
+    SalishSeaCast NEMO Command Processor
 
-  optional arguments:
-    --version            show program's version number and exit
-    -v, --verbose        Increase verbosity of output. Can be repeated.
-    -q, --quiet          Suppress output except warnings and errors.
-    --log-file LOG_FILE  Specify a file to log output. Disabled by default.
-    -h, --help           Show help message and exit.
-    --debug              Show tracebacks on errors.
+    optional arguments:
+      --version            show program's version number and exit
+      -v, --verbose        Increase verbosity of output. Can be repeated.
+      -q, --quiet          Suppress output except warnings and errors.
+      --log-file LOG_FILE  Specify a file to log output. Disabled by default.
+      -h, --help           Show help message and exit.
+      --debug              Show tracebacks on errors.
 
-  Commands:
-    combine        Combine per-processor files from an MPI NEMO run into single files (NEMO-Cmd)
-    complete       print bash completion command (cliff)
-    deflate        Deflate variables in netCDF files using Lempel-Ziv compression. (NEMO-Cmd)
-    gather         Gather results from a NEMO run. (NEMO-Cmd)
-    help           print detailed help for another command (cliff)
-    prepare        Prepare a SalishSeaCast NEMO run.
-    run            Prepare, execute, and gather results from a SalishSeaCast NEMO model run.
-    split-results  Split the results of a multi-day SalishSeaCast NEMO model run
-                   (e.g. a hindcast run) into daily results directories.
+    Commands:
+      combine        Combine per-processor files from an MPI NEMO run into single files (NEMO-Cmd)
+      complete       print bash completion command (cliff)
+      deflate        Deflate variables in netCDF files using Lempel-Ziv compression. (NEMO-Cmd)
+      gather         Gather results from a NEMO run. (NEMO-Cmd)
+      help           print detailed help for another command (cliff)
+      prepare        Prepare a SalishSeaCast NEMO run.
+      run            Prepare, execute, and gather results from a SalishSeaCast NEMO model run.
+      split-results  Split the results of a multi-day SalishSeaCast NEMO model run
+                     (e.g. a hindcast run) into daily results directories.
 
 For details of the arguments and options for a sub-command use
 :command:`pixi run salishsea help <sub-command>`.
 For example:
 
-.. code-block:: bash
+.. code-block:: console
 
-    pixi run salishsea help run
-
-.. code-block:: text
+    $ pixi run salishsea help run
 
     usage: salishsea run [-h] [--cores-per-node CORES_PER_NODE] [--cpu-arch CPU_ARCH]
                          [--deflate] [--max-deflate-jobs MAX_DEFLATE_JOBS]
@@ -119,9 +118,9 @@ For example:
 
 You can check what version of :program:`salishsea` you have installed with:
 
-.. code-block:: bash
+.. code-block:: console
 
-    pixi run salishsea --version
+    $ pixi run salishsea --version
 
 A common use-case is to execute the :command:`salishsea run` command in the directory containing
 your run description YAML file.
@@ -131,11 +130,11 @@ correct environment.
 We do that by using the ``-m`` or ``--manifest`` option of :command:`pixi run`.
 Example:
 
-.. code-block:: bash
+.. code-block:: console
 
-    cd SS-run-sets/SalishSea/sea/Carbon_v202111/
-    pixi run -m $HOME/MEOPAR/SalishSeaCmd salishsea run 01jan11_Lb80.yaml \
-      /scratch/allen/Carbon/MoreSens/Now/01jan11/
+    $ cd SS-run-sets/SalishSea/sea/Carbon_v202111/
+    $ pixi run -m $HOME/MEOPAR/SalishSeaCmd salishsea run 01jan11_Lb80.yaml \
+        /scratch/allen/Carbon/MoreSens/Now/01jan11/
 
 
 .. _salishsea-run:
@@ -150,6 +149,7 @@ description file.
 The results are gathered in the specified results directory.
 
 .. code-block:: text
+   :class: no-copybutton
 
     usage: salishsea run [-h] [--cores-per-node CORES_PER_NODE] [--cpu-arch CPU_ARCH]
                          [--deflate] [--max-deflate-jobs MAX_DEFLATE_JOBS]
@@ -232,9 +232,9 @@ See the :ref:`RunDescriptionFileStructure` section for details of the run descri
 The :command:`run` sub-command concludes by printing the path to the run directory and the response from the job queue manager.
 Example:
 
-.. code-block:: bash
+.. code-block:: console
 
-    pixi run salishsea run SalishSea.yaml $HOME/MEOPAR/SalishSea/myrun
+    $ pixi run salishsea run SalishSea.yaml $HOME/MEOPAR/SalishSea/myrun
 
     salishsea_cmd.run INFO: salishsea_cmd.prepare Created run directory /global/scratch/sallen/20mar17hindcast_2017-10-01T183841.082501-0700
     salishsea_cmd.run INFO: 3330782.orca2.ibb
@@ -265,9 +265,9 @@ and :kbd:`dia[12]_T`.
 The output of a :command:`run --separate-deflate` sub-command includes information from the job queue manager about the NEMO job and the 3 deflate jobs.
 Example:
 
-.. code-block:: bash
+.. code-block:: console
 
-    pixi run salishsea run SalishSea.yaml $HOME/MEOPAR/SalishSea/myrun
+    $ pixi run salishsea run SalishSea.yaml $HOME/MEOPAR/SalishSea/myrun
 
     salishsea_cmd.run INFO: salishsea_cmd.prepare Created run directory ../../SalishSea/20mar17hindcast_2017-10-01T183841.082501-0700
     salishsea_cmd.run INFO: SalishSeaNEMO.sh queued as 3330782.orca2.ibb
@@ -286,6 +286,7 @@ SalishSeaCast NEMO run described in the specified run description,
 and IOM server definitions files:
 
 .. code-block:: text
+   :class: no-copybutton
 
     usage: salishsea prepare [-h] [--nemo3.4] [-q] DESC_FILE
 
@@ -306,9 +307,9 @@ See the :ref:`RunDescriptionFileStructure` section for details of the run descri
 The :command:`prepare` sub-command concludes by printing the path to the run directory it created.
 Example:
 
-.. code-block:: bash
+.. code-block:: console
 
-    pixi run salishsea prepare SalishSea.yaml iodef.xml
+    $ pixi run salishsea prepare SalishSea.yaml iodef.xml
 
     salishsea_cmd.prepare INFO: Created run directory /scratch/dlatorne/MEOPAR/runs/01mar23-11x32_2025-12-24T145433.665751-0800
 
@@ -396,9 +397,9 @@ The :command:`combine` sub-command combines the per-processor results and/or res
 It is provided by the `NEMO-Cmd`_ package.
 Please use:
 
-.. code-block:: bash
+.. code-block:: console
 
-    pixi run salishsea help combine
+    $ pixi run salishsea help combine
 
 to see its usage,
 and see :ref:`nemocmd:nemo-combine` for more details.
@@ -418,9 +419,9 @@ The :command:`deflate` sub-command deflates the variables in netCDF files using 
 It is provided by the `NEMO-Cmd`_ package.
 Please use:
 
-.. code-block:: bash
+.. code-block:: console
 
-    pixi run salishsea help deflate
+    $ pixi run salishsea help deflate
 
 to see its usage,
 and see :ref:`nemocmd:nemo-deflate` for more details.
@@ -438,9 +439,9 @@ The :command:`gather` sub-command moves results from a NEMO run into a results d
 It is provided by the `NEMO-Cmd`_ package.
 Please use:
 
-.. code-block:: bash
+.. code-block:: console
 
-    pixi run salishsea help gather
+    $ pixi run salishsea help gather
 
 to see its usage,
 and see :ref:`nemocmd:nemo-gather` for more details.
@@ -468,6 +469,7 @@ The restart files are moved to the last run day's directory.
 .. _file_def_dailysplit.xml: https://github.com/SalishSeaCast/SS-run-sets/blob/main/v201905/hindcast/file_def_dailysplit.xml
 
 .. code-block:: text
+   :class: no-copybutton
 
     usage: salishsea split-results [-h] [-q] SOURCE_DIR
 


### PR DESCRIPTION
- Replaced `code-block:: bash` with `code-block:: console` in documentation files.
- Added `$` prompt to command examples to align with standard usage.
- Configured the `sphinx_copybutton` extension with the following improvements:
  - Set a regex for the prompt text.
  - Ensured it respects bash line continuation characters.
  - Introduced a `no-copybutton` class to suppress the copy button where needed.
