### PR TITLE
Add support for `rorqual` HPC cluster

### DIFF
--- a/salishsea_cmd/run.py
+++ b/salishsea_cmd/run.py
@@ -277,6 +277,7 @@ def run(
             "fir": "sbatch",
             "narval": "sbatch",
             "nibi": "sbatch",
+            "rorqual": "sbatch",
             "trillium": "sbatch",
             # UBC ARC sockeye cluster
             "sockeye": "sbatch",
@@ -664,6 +665,7 @@ def _build_batch_script(
         "fir",
         "narval",
         "nibi",
+        "rorqual",
         "trillium",
         # UBC ARC sockeye cluster
         "sockeye",
@@ -673,6 +675,7 @@ def _build_batch_script(
             "fir": 192 if not cores_per_node else int(cores_per_node),
             "narval": 64 if not cores_per_node else int(cores_per_node),
             "nibi": 192 if not cores_per_node else int(cores_per_node),
+            "rorqual": 192 if not cores_per_node else int(cores_per_node),
             "trillium": 192 if not cores_per_node else int(cores_per_node),
             # UBC ARC sockeye cluster
             "sockeye": 40 if not cores_per_node else int(cores_per_node),
@@ -773,6 +776,7 @@ def _sbatch_directives(
         "fir": "0",
         "narval": "0",
         "nibi": "0",
+        "rorqual": "0",
         # Not used on trillium
         # UBC ARC sockeye cluster
         "sockeye": "186gb",
@@ -987,6 +991,10 @@ def _modules():
             module load StdEnv/2023
             module load netcdf-fortran-mpi/4.6.1
             """),
+        "rorqual": textwrap.dedent("""\
+            module load StdEnv/2023
+            module load netcdf-fortran-mpi/4.6.1
+            """),
         "trillium": textwrap.dedent("""\
             module load StdEnv/2023
             module load gcc/12.3
@@ -1037,6 +1045,7 @@ def _execute(
         "fir": "mpirun",
         "narval": "mpirun",
         "nibi": "mpirun",
+        "rorqual": "mpirun",
         "trillium": "mpirun",
         # UBC ARC sockeye cluster
         "sockeye": "mpirun",
@@ -1052,6 +1061,7 @@ def _execute(
         "fir": f"{mpirun} -np {nemo_processors} ./nemo.exe",
         "narval": f"{mpirun} -np {nemo_processors} ./nemo.exe",
         "nibi": f"{mpirun} -np {nemo_processors} ./nemo.exe",
+        "rorqual": f"{mpirun} -np {nemo_processors} ./nemo.exe",
         "trillium": f"{mpirun} -np {nemo_processors} ./nemo.exe",
         # UBC ARC sockeye cluster
         "sockeye": f"{mpirun} -np {nemo_processors} ./nemo.exe",
@@ -1068,6 +1078,7 @@ def _execute(
             "fir": f"{mpirun} : -np {xios_processors} ./xios_server.exe{redirect}",
             "narval": f"{mpirun} : -np {xios_processors} ./xios_server.exe{redirect}",
             "nibi": f"{mpirun} : -np {xios_processors} ./xios_server.exe{redirect}",
+            "rorqual": f"{mpirun} : -np {xios_processors} ./xios_server.exe{redirect}",
             "trillium": f"{mpirun} : -np {xios_processors} ./xios_server.exe{redirect}",
             # UBC ARC sockeye cluster
             "sockeye": f"{mpirun} : -np {xios_processors} ./xios_server.exe{redirect}",
@@ -1115,7 +1126,7 @@ def _execute(
 
             echo "Results deflation started at $(date)"{redirect}
             """)
-        if SYSTEM in {"fir", "narval", "nibi", "trillium"}:
+        if SYSTEM in {"fir", "narval", "nibi", "rorqual", "trillium"}:
             # Load the nco module just before deflation because it replaces
             # the netcdf-mpi and netcdf-fortran-mpi modules with their non-mpi
             # variants

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -180,6 +180,8 @@ class TestRun:
             (True, 4, "narval", "sbatch", "Submitted batch job 43"),
             (False, 0, "nibi", "sbatch", "Submitted batch job 43"),
             (True, 4, "nibi", "sbatch", "Submitted batch job 43"),
+            (False, 0, "rorqual", "sbatch", "Submitted batch job 43"),
+            (True, 4, "rorqual", "sbatch", "Submitted batch job 43"),
             (False, 0, "trillium", "sbatch", "Submitted batch job 43"),
             (True, 4, "trillium", "sbatch", "Submitted batch job 43"),
             # UBC ARC sockeye cluster
@@ -254,6 +256,8 @@ class TestRun:
             (True, 4, "narval", "sbatch", "Submitted batch job 43"),
             (False, 0, "nibi", "sbatch", "Submitted batch job 43"),
             (True, 4, "nibi", "sbatch", "Submitted batch job 43"),
+            (False, 0, "rorqual", "sbatch", "Submitted batch job 43"),
+            (True, 4, "rorqual", "sbatch", "Submitted batch job 43"),
             (False, 0, "trillium", "sbatch", "Submitted batch job 43"),
             (True, 4, "trillium", "sbatch", "Submitted batch job 43"),
             # UBC ARC sockeye cluster
@@ -423,6 +427,8 @@ class TestRun:
             (True, 4, "narval", "sbatch", "Submitted batch job 43"),
             (False, 0, "nibi", "sbatch", "Submitted batch job 43"),
             (True, 4, "nibi", "sbatch", "Submitted batch job 43"),
+            (False, 0, "rorqual", "sbatch", "Submitted batch job 43"),
+            (True, 4, "rorqual", "sbatch", "Submitted batch job 43"),
             (False, 0, "trillium", "sbatch", "Submitted batch job 43"),
             (True, 4, "trillium", "sbatch", "Submitted batch job 43"),
             # UBC ARC sockeye cluster
@@ -538,6 +544,22 @@ class TestRun:
                 True,
                 4,
                 "nibi",
+                "sbatch",
+                ("Submitted batch job 43", "Submitted batch job 44"),
+                "Submitted batch job 43",
+            ),
+            (
+                False,
+                0,
+                "rorqual",
+                "sbatch",
+                ("Submitted batch job 43", "Submitted batch job 44"),
+                "Submitted batch job 43",
+            ),
+            (
+                True,
+                4,
+                "rorqual",
                 "sbatch",
                 ("Submitted batch job 43", "Submitted batch job 44"),
                 "Submitted batch job 43",
@@ -747,6 +769,22 @@ class TestRun:
                 True,
                 4,
                 "nibi",
+                "sbatch",
+                ("Submitted batch job 43", "Submitted batch job 44"),
+                "Submitted batch job 43",
+            ),
+            (
+                False,
+                0,
+                "rorqual",
+                "sbatch",
+                ("Submitted batch job 43", "Submitted batch job 44"),
+                "Submitted batch job 43",
+            ),
+            (
+                True,
+                4,
+                "rorqual",
                 "sbatch",
                 ("Submitted batch job 43", "Submitted batch job 44"),
                 "Submitted batch job 43",
@@ -2233,6 +2271,100 @@ class TestBuildBatchScript:
         assert script == expected
 
     @pytest.mark.parametrize("deflate", [True, False])
+    def test_rorqual(self, mock_path, deflate, monkeypatch):
+        desc_file = StringIO(
+            "run_id: foo\n" "walltime: 01:02:03\n" "email: me@example.com"
+        )
+        run_desc = yaml.safe_load(desc_file)
+        monkeypatch.setattr(salishsea_cmd.run, "SYSTEM", "rorqual")
+
+        script = salishsea_cmd.run._build_batch_script(
+            run_desc,
+            Path("SalishSea.yaml"),
+            nemo_processors=42,
+            xios_processors=1,
+            max_deflate_jobs=4,
+            results_dir=Path("results_dir"),
+            run_dir=Path("tmp_run_dir"),
+            deflate=deflate,
+            separate_deflate=False,
+            cores_per_node="",
+            cpu_arch="",
+        )
+
+        expected = textwrap.dedent("""\
+            #!/bin/bash
+
+            #SBATCH --job-name=foo
+            #SBATCH --nodes=1
+            #SBATCH --ntasks-per-node=192
+            #SBATCH --mem=0
+            #SBATCH --time=1:02:03
+            #SBATCH --mail-user=me@example.com
+            #SBATCH --mail-type=ALL
+            #SBATCH --account=def-allen
+            # stdout and stderr file paths/names
+            #SBATCH --output=results_dir/stdout
+            #SBATCH --error=results_dir/stderr
+
+
+            RUN_ID="foo"
+            RUN_DESC="tmp_run_dir/SalishSea.yaml"
+            WORK_DIR="tmp_run_dir"
+            RESULTS_DIR="results_dir"
+            COMBINE="pixi run -m $HOME/MEOPAR/SalishSeaCmd salishsea combine"
+            """)
+        if deflate:
+            expected += textwrap.dedent("""\
+                DEFLATE="pixi run -m $HOME/MEOPAR/SalishSeaCmd salishsea deflate"
+                """)
+        expected += textwrap.dedent("""\
+            GATHER="pixi run -m $HOME/MEOPAR/SalishSeaCmd salishsea gather"
+
+            module load StdEnv/2023
+            module load netcdf-fortran-mpi/4.6.1
+
+            mkdir -p ${RESULTS_DIR}
+            cd ${WORK_DIR}
+            echo "working dir: $(pwd)"
+
+            echo "Starting run at $(date)"
+            mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe
+            MPIRUN_EXIT_CODE=$?
+            echo "Ended run at $(date)"
+
+            echo "Results combining started at $(date)"
+            ${COMBINE} ${RUN_DESC} --debug
+            echo "Results combining ended at $(date)"
+            """)
+        if deflate:
+            expected += textwrap.dedent("""\
+
+                echo "Results deflation started at $(date)"
+                module load nco/4.9.5
+                ${DEFLATE} *_ptrc_T*.nc *_prod_T*.nc *_carp_T*.nc *_grid_[TUVW]*.nc \\
+                  *_turb_T*.nc *_dia[12n]_T*.nc FVCOM*.nc Slab_[UV]*.nc *_mtrc_T*.nc \\
+                  --jobs 4 --debug
+                echo "Results deflation ended at $(date)"
+                """)
+        expected += textwrap.dedent("""\
+
+            echo "Results gathering started at $(date)"
+            ${GATHER} ${RESULTS_DIR} --debug
+            echo "Results gathering ended at $(date)"
+
+            chmod go+rx ${RESULTS_DIR}
+            chmod g+rw ${RESULTS_DIR}/*
+            chmod o+r ${RESULTS_DIR}/*
+
+            echo "Deleting run directory" >>${RESULTS_DIR}/stdout
+            rmdir $(pwd)
+            echo "Finished at $(date)" >>${RESULTS_DIR}/stdout
+            exit ${MPIRUN_EXIT_CODE}
+            """)
+        assert script == expected
+
+    @pytest.mark.parametrize("deflate", [True, False])
     def test_trillium(self, mock_path, deflate, monkeypatch):
         desc_file = StringIO(
             "run_id: foo\n" "walltime: 01:02:03\n" "email: me@example.com"
@@ -2861,6 +2993,43 @@ class TestSbatchDirectives:
         )
         assert slurm_directives == expected
 
+    def test_rorqual_sbatch_directives(self, caplog, monkeypatch):
+        desc_file = StringIO("run_id: foo\n" "walltime: 01:02:03\n")
+        run_desc = yaml.safe_load(desc_file)
+        monkeypatch.setattr(salishsea_cmd.run, "SYSTEM", "rorqual")
+        caplog.set_level(logging.DEBUG)
+
+        slurm_directives = salishsea_cmd.run._sbatch_directives(
+            run_desc,
+            n_processors=43,
+            procs_per_node=192,
+            cpu_arch="",
+            email="me@example.com",
+            results_dir=Path("foo"),
+        )
+
+        assert caplog.records[0].levelname == "INFO"
+        expected = (
+            f"No account found in run description YAML file, "
+            f"so assuming def-allen. If sbatch complains you can specify a "
+            f"different account with a YAML line like account: def-allen"
+        )
+        assert caplog.records[0].message == expected
+        expected = (
+            "#SBATCH --job-name=foo\n"
+            "#SBATCH --nodes=1\n"
+            "#SBATCH --ntasks-per-node=192\n"
+            "#SBATCH --mem=0\n"
+            "#SBATCH --time=1:02:03\n"
+            "#SBATCH --mail-user=me@example.com\n"
+            "#SBATCH --mail-type=ALL\n"
+            "#SBATCH --account=def-allen\n"
+            "# stdout and stderr file paths/names\n"
+            "#SBATCH --output=foo/stdout\n"
+            "#SBATCH --error=foo/stderr\n"
+        )
+        assert slurm_directives == expected
+
     def test_trillium_sbatch_directives(self, caplog, monkeypatch):
         desc_file = StringIO("run_id: foo\n" "walltime: 01:02:03\n")
         run_desc = yaml.safe_load(desc_file)
@@ -3177,8 +3346,8 @@ class TestModules:
 
         assert modules == ""
 
-    @pytest.mark.parametrize("system", ["fir", "narval", "nibi"])
-    def test_2025_alliance_clusters(self, system, monkeypatch):
+    @pytest.mark.parametrize("system", ["fir", "narval", "nibi", "rorqual"])
+    def test_2025_alliance_clusters_except_trillium(self, system, monkeypatch):
         monkeypatch.setattr(salishsea_cmd.run, "SYSTEM", system)
 
         modules = salishsea_cmd.run._modules()
@@ -3248,7 +3417,11 @@ class TestExecute:
         "system, mpirun_cmd",
         [
             # Alliance Canada clusters
+            ("fir", "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe"),
             ("narval", "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe"),
+            ("nibi", "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe"),
+            ("rorqual", "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe"),
+            ("trillium", "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe"),
             # UBC ARC sockeye cluster
             (
                 "sockeye",
@@ -3302,7 +3475,7 @@ class TestExecute:
 
             echo "Results deflation started at $(date)"
             """)
-        if system in {"fir", "narval", "nibi", "trillium"}:
+        if system in {"fir", "narval", "nibi", "rorqual", "trillium"}:
             expected += textwrap.dedent("""\
                 module load nco/4.9.5
                 """)
@@ -3376,6 +3549,12 @@ class TestExecute:
             ),
             (
                 "nibi",
+                "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe",
+                False,
+                False,
+            ),
+            (
+                "rorqual",
                 "mpirun -np 42 ./nemo.exe : -np 1 ./xios_server.exe",
                 False,
                 False,


### PR DESCRIPTION
Extended cluster configuration to include `rorqual`, aligning it with existing HPC systems like `fir` and `nibi`. Updated tests, batch scripts, and module directives to ensure compatibility with `rorqual`.

The changes in this commit were almost entirely produced by the PyCharm Junie AI agent. Most of my review edits were minor. The exception was `TestBuildBatchScript.test_rorqual()` where the agent used a hack to generate the expected script from a call for `fir`. I prefer that we test against the hand-coded expected script.