### PR TITLE
Improve GitHub Actions workflows based on `zizmor` static analysis

### DIFF
--- a/.github/workflows/add-milestone-issue-pr.yaml
+++ b/.github/workflows/add-milestone-issue-pr.yaml
@@ -17,4 +17,4 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    uses: UBC-MOAD/gha-workflows/.github/workflows/auto-milestone-issue-pr.yaml@main
+    uses: UBC-MOAD/gha-workflows/.github/workflows/auto-milestone-issue-pr.yaml@main  # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/add-milestone-issue-pr.yaml
+++ b/.github/workflows/add-milestone-issue-pr.yaml
@@ -1,5 +1,7 @@
 name: Add Milestone to Issue/PR
 
+permissions: {}
+
 on:
   issues:
     types:

--- a/.github/workflows/add-milestone-issue-pr.yaml
+++ b/.github/workflows/add-milestone-issue-pr.yaml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   add_milestone:
+    name: Add current milestone to Issue/PR
     permissions:
       issues: write  # Required for adding milestones to issues
       pull-requests: write  # Required for adding milestones to pull requests

--- a/.github/workflows/add-milestone-issue-pr.yaml
+++ b/.github/workflows/add-milestone-issue-pr.yaml
@@ -15,6 +15,6 @@ on:
 jobs:
   add_milestone:
     permissions:
-      issues: write
-      pull-requests: write
+      issues: write  # Required for adding milestones to issues
+      pull-requests: write  # Required for adding milestones to pull requests
     uses: UBC-MOAD/gha-workflows/.github/workflows/auto-milestone-issue-pr.yaml@main  # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/assign-issue-pr.yaml
+++ b/.github/workflows/assign-issue-pr.yaml
@@ -15,6 +15,6 @@ on:
 jobs:
   auto_assign:
     permissions:
-      issues: write
-      pull-requests: write
+      issues: write  # Required to add assignee to an issue
+      pull-requests: write  # Required to add assignee to a pull request
     uses: UBC-MOAD/gha-workflows/.github/workflows/auto-assign.yaml@main  # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/assign-issue-pr.yaml
+++ b/.github/workflows/assign-issue-pr.yaml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   auto_assign:
+    name: Automatically assign issues and PRs to Doug
     permissions:
       issues: write  # Required to add assignee to an issue
       pull-requests: write  # Required to add assignee to a pull request

--- a/.github/workflows/assign-issue-pr.yaml
+++ b/.github/workflows/assign-issue-pr.yaml
@@ -11,9 +11,10 @@ on:
     types:
       - reopened
       - opened
+
 jobs:
   auto_assign:
     permissions:
       issues: write
       pull-requests: write
-    uses: UBC-MOAD/gha-workflows/.github/workflows/auto-assign.yaml@main
+    uses: UBC-MOAD/gha-workflows/.github/workflows/auto-assign.yaml@main  # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/assign-issue-pr.yaml
+++ b/.github/workflows/assign-issue-pr.yaml
@@ -1,4 +1,7 @@
 name: Assign Issue/PR
+
+permissions: {}
+
 on:
   issues:
     types:

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -19,6 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         language: [ 'python' ]
-    uses: UBC-MOAD/gha-workflows/.github/workflows/codeql-analysis.yaml@main
+    uses: UBC-MOAD/gha-workflows/.github/workflows/codeql-analysis.yaml@main  # zizmor: ignore[unpinned-uses]
     with:
       language: ${{ matrix.language }}

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -12,9 +12,9 @@ jobs:
   analyze:
     name: Analyze
     permissions:
-      actions: read
-      contents: read
-      security-events: write
+      actions: read  # Required to run CodeQL analysis
+      contents: read  # Required to access the repository's source code
+      security-events: write  # Required to upload CodeQL analysis results to GitHub
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -1,4 +1,6 @@
-name: "CodeQL"
+name: CodeQL
+
+permissions: {}
 
 on:
   push:

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   analyze:
-    name: Analyze
+    name: CodeQL analysis for ${{ inputs.language }}
     permissions:
       actions: read  # Required to run CodeQL analysis
       contents: read  # Required to access the repository's source code

--- a/.github/workflows/pytest-with-coverage.yaml
+++ b/.github/workflows/pytest-with-coverage.yaml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         environment: [ 'test-py312', 'test-py313', 'test-py314' ]
 
-    uses: UBC-MOAD/gha-workflows/.github/workflows/pixi-pytest-with-coverage.yaml@main
+    uses: UBC-MOAD/gha-workflows/.github/workflows/pixi-pytest-with-coverage.yaml@main  # zizmor: ignore[unpinned-uses]
     with:
       environment: ${{ matrix.environment }}
     secrets:

--- a/.github/workflows/pytest-with-coverage.yaml
+++ b/.github/workflows/pytest-with-coverage.yaml
@@ -1,5 +1,7 @@
 name: pytest-with-coverage
 
+permissions: {}
+
 on:
   push:
     branches: [ '*' ]

--- a/.github/workflows/pytest-with-coverage.yaml
+++ b/.github/workflows/pytest-with-coverage.yaml
@@ -12,8 +12,8 @@ on:
 jobs:
   pytest-with-coverage:
     permissions:
-      contents: read
-      pull-requests: write
+      contents: read  # Required to access the repository's source code
+      pull-requests: write  # Required to upload coverage results to pull requests
 
     strategy:
       fail-fast: false

--- a/.github/workflows/pytest-with-coverage.yaml
+++ b/.github/workflows/pytest-with-coverage.yaml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   pytest-with-coverage:
+    name: pytest with coverage
     permissions:
       contents: read  # Required to access the repository's source code
       pull-requests: write  # Required to upload coverage results to pull requests

--- a/.github/workflows/sphinx-linkcheck.yaml
+++ b/.github/workflows/sphinx-linkcheck.yaml
@@ -13,4 +13,4 @@ jobs:
     permissions:
       contents: read
 
-    uses: UBC-MOAD/gha-workflows/.github/workflows/pixi-sphinx-linkcheck.yaml@main
+    uses: UBC-MOAD/gha-workflows/.github/workflows/pixi-sphinx-linkcheck.yaml@main  # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/sphinx-linkcheck.yaml
+++ b/.github/workflows/sphinx-linkcheck.yaml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   sphinx-linkcheck:
+    name: Sphinx linkcheck
     permissions:
       contents: read  # Required to access the repository's source code
 

--- a/.github/workflows/sphinx-linkcheck.yaml
+++ b/.github/workflows/sphinx-linkcheck.yaml
@@ -1,5 +1,7 @@
 name: sphinx-linkcheck
 
+permissions: {}
+
 on:
   push:
     branches: [ '*' ]

--- a/.github/workflows/sphinx-linkcheck.yaml
+++ b/.github/workflows/sphinx-linkcheck.yaml
@@ -11,6 +11,6 @@ on:
 jobs:
   sphinx-linkcheck:
     permissions:
-      contents: read
+      contents: read  # Required to access the repository's source code
 
     uses: UBC-MOAD/gha-workflows/.github/workflows/pixi-sphinx-linkcheck.yaml@main  # zizmor: ignore[unpinned-uses]


### PR DESCRIPTION
* locked down permissions in all workflows to prevent leakage of default permissions
* added pragma comments to tell `zizmor` to ignore unpinned uses of our own reusable workflows
* added explanatory comments to permissions items
* added names to anonymous workflow jobs to improve readability in GitHub Actions UI